### PR TITLE
feat(ci-baton): capability-routed, attested CI-check Baton + sweep tool

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,15 +10,13 @@
 # supported CodeQL languages.
 #
 name: "CodeQL Advanced"
-
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
   schedule:
     - cron: '28 16 * * 0'
-
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
@@ -32,14 +30,11 @@ jobs:
     permissions:
       # required for all workflows
       security-events: write
-
       # required to fetch internal or private CodeQL packs
       packages: read
-
       # only required for workflows in private repositories
       actions: read
       contents: read
-
     strategy:
       fail-fast: false
       matrix:
@@ -53,46 +48,43 @@ jobs:
         # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      # Add any setup steps before running the `github/codeql-action/init` action.
+      # This includes steps like installing compilers or runtimes (`actions/setup-node`
+      # or others). This is typically only required for manual builds.
+      # - name: Setup runtime (example)
+      #   uses: actions/setup-example@v1
 
-    # Add any setup steps before running the `github/codeql-action/init` action.
-    # This includes steps like installing compilers or runtimes (`actions/setup-node`
-    # or others). This is typically only required for manual builds.
-    # - name: Setup runtime (example)
-    #   uses: actions/setup-example@v1
-
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
-      with:
-        languages: ${{ matrix.language }}
-        build-mode: ${{ matrix.build-mode }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+      # If the analyze step fails for one of the languages you are analyzing with
+      # "We were unable to automatically build your code", modify the matrix above
+      # to set the build mode to "manual" for that language. Then modify this step
+      # to build your code.
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+      - name: Run manual build steps
         # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
 
-    # If the analyze step fails for one of the languages you are analyzing with
-    # "We were unable to automatically build your code", modify the matrix above
-    # to set the build mode to "manual" for that language. Then modify this step
-    # to build your code.
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-    - name: Run manual build steps
-      if: matrix.build-mode == 'manual'
-      shell: bash
-      run: |
-        echo 'If you are using a "manual" build mode for one or more of the' \
-          'languages you are analyzing, replace this with the commands to build' \
-          'your code, for example:'
-        echo '  make bootstrap'
-        echo '  make release'
-        exit 1
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
-      with:
-        category: "/language:${{matrix.language}}"
+        if: matrix.build-mode == 'manual'
+        shell: bash
+        run: |
+          echo 'If you are using a "manual" build mode for one or more of the' \
+            'languages you are analyzing, replace this with the commands to build' \
+            'your code, for example:'
+          echo '  make bootstrap'
+          echo '  make release'
+          exit 1
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{matrix.language}}"

--- a/.machine_readable/6a2/AGENTIC.a2ml
+++ b/.machine_readable/6a2/AGENTIC.a2ml
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
+#
+# AGENTIC.a2ml — AI agent constraints and capabilities
+# Defines what AI agents can and cannot do in this repository.
+
+[metadata]
+version = "0.1.0"
+last-updated = "2026-04-11"
+
+[agent-permissions]
+can-edit-source = true
+can-edit-tests = true
+can-edit-docs = true
+can-edit-config = true
+can-create-files = true
+
+[agent-constraints]
+# What AI agents must NOT do:
+# - Never use banned language patterns (believe_me, unsafeCoerce, etc.)
+# - Never commit secrets or credentials
+# - Never use banned languages (TypeScript, Python, Go, etc.)
+# - Never place state files in repository root (must be in .machine_readable/)
+# - Never use AGPL license (use MPL-2.0)
+
+[maintenance-integrity]
+fail-closed = true
+require-evidence-per-step = true
+allow-silent-skip = false
+require-rerun-after-fix = true
+release-claim-requires-hard-pass = true
+
+# ============================================================================
+# METHODOLOGY (ADR-002)
+# ============================================================================
+# Detailed methodology configuration lives in:
+#   .machine_readable/bot_directives/methodology.a2ml
+#   .machine_readable/bot_directives/coverage.a2ml
+#   .machine_readable/bot_directives/debt.a2ml
+#
+# AGENTIC.a2ml declares WHAT agents can do (permissions, gating).
+# bot_directives/ declares HOW agents should work (methodology).
+
+[methodology]
+instructions-dir = ".machine_readable/bot_directives/"
+default-mode = "hybrid"
+
+[automation-hooks]
+# on-enter: Read 0-AI-MANIFEST.a2ml, then STATE.a2ml, then bot_directives/
+# on-exit: Update STATE.a2ml, coverage.a2ml, and debt.a2ml with session outcomes
+# on-commit: Run just validate-rsr

--- a/.machine_readable/6a2/ECOSYSTEM.a2ml
+++ b/.machine_readable/6a2/ECOSYSTEM.a2ml
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: MPL-2.0
+# ECOSYSTEM.a2ml — Ecosystem position
+# Converted from ECOSYSTEM.scm on 2026-04-14
+
+[metadata]
+project = "pseudoscript"
+ecosystem = "hyperpolymath"
+
+[position]
+type = "programming-language"
+purpose = "Pseudocode-syntax AffineScript. Write code that looks like pseudocode. Get affine resource guarantees and typed WASM out."
+
+[pipeline]
+position = "co-product"
+chain = "katagoria → typell → typed-wasm → PanLL"
+notes = "PseudoScript compiles to typed WasmGC. TypeLL grounds its type system. typed-wasm provides the shared binary layout and ABI conventions."
+coordination = "nextgen-typing"
+
+[related-projects]
+projects = [
+  { name = "typell", relationship = "type-theory-foundation", notes = "TypeLL's open-ended progressive framework grounds PseudoScript's type system. typell-pseudoscript bridge crate." },
+  { name = "typed-wasm", relationship = "aggregate-library", notes = "Shared binary layout conventions for WasmGC cross-language calls. PseudoScript Option[T]/Result[T,E]/String have agreed layouts here." },
+  { name = "nextgen-typing", relationship = "coordination-parent", notes = "Coordination monorepo for the type theory pipeline. Canonical architecture doc." },
+  { name = "affinescript", relationship = "foundation", notes = "PseudoScript is a syntactic face of AffineScript." },
+  { name = "rattlescript", relationship = "sibling", notes = "Both are syntactic faces of AffineScript." },
+  { name = "ephapax", relationship = "sibling-wasm-target", notes = "Both compile to typed WasmGC. Independent designs; converge at binary level via typed-wasm." },
+  { name = "katagoria", relationship = "research-upstream", notes = "Type theory research origination. Future PseudoScript type system extensions may originate there." },
+  { name = "panll", relationship = "consumer", notes = "PseudoScript is one of PanLL's development language targets." },
+]

--- a/.machine_readable/6a2/META.a2ml
+++ b/.machine_readable/6a2/META.a2ml
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
+#
+# META.a2ml — Project meta-level information
+# Architecture decisions, design rationale, governance.
+
+[metadata]
+version = "0.1.0"
+last-updated = "2026-04-11"
+
+[project-info]
+type = "library"  # TODO: update type (library|binary|service|website|monorepo)  # library | binary | monorepo | service | website
+languages = []             # e.g. ["rust", "zig", "idris2"]
+license = "MPL-2.0"
+author = "Jonathan D.A. Jewell (hyperpolymath)"
+
+[architecture-decisions]
+# ADR format: status = proposed | accepted | deprecated | superseded | rejected
+# - { id = "ADR-001", title = "Use Zig for FFI", status = "accepted", date = "2026-02-14" }
+
+[development-practices]
+build-tool = "just"
+container-runtime = "podman"
+ci-platform = "github-actions"
+package-manager = "guix"  # guix | nix | cargo | mix
+
+[maintenance-axes]
+scoping-first = true
+execution-order = "axis-1 > axis-2 > axis-3"
+axis-1 = "must > intend > like"
+axis-2 = "corrective > adaptive > perfective"
+axis-3 = "systems > compliance > effects"
+
+[scoping]
+sources = "README, roadmap, status docs, maintenance checklist, CI/security docs"
+marker-scan = "TODO/FIXME/XXX/HACK/STUB/PARTIAL"
+idris-unsound-scan = "believe_me/assert_total"
+
+[axis-2-maintenance-rules]
+corrective-first = true
+adaptive-second = true
+adaptive-focus = "scope-change reconciliation, stale-reference removal, obsolete-work culling"
+perfective-third = true
+perfective-source = "axis-1 honest state after corrective/adaptive updates"
+
+[axis-3-audit-rules]
+audit-focus = "systems in place, documentation explains actual state, safety/security accounted for, observed effects reviewed"
+compliance-focus = "seams/compromises/exception register, bounded exceptions, anti-drift checks"
+drift-risk-example = "single exception broadening into policy violation (e.g. ReScript->TypeScript spread)"
+effects-evidence = "benchmark execution/results and maintainer status dialogue/review"
+
+[design-rationale]
+# Key design decisions and their reasoning

--- a/.machine_readable/6a2/NEUROSYM.a2ml
+++ b/.machine_readable/6a2/NEUROSYM.a2ml
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
+#
+# NEUROSYM.a2ml — Neurosymbolic integration metadata
+# Configuration for Hypatia scanning and symbolic reasoning.
+
+[metadata]
+version = "0.1.0"
+last-updated = "2026-04-11"
+
+[hypatia-config]
+scan-enabled = true
+scan-depth = "standard"  # quick | standard | deep
+report-format = "logtalk"
+
+[symbolic-rules]
+# Custom symbolic rules for this project
+# - { name = "no-unsafe-ffi", pattern = "believe_me|unsafeCoerce", severity = "critical" }
+
+[neural-config]
+# Neural pattern detection settings
+# confidence-threshold = 0.85
+# model = "hypatia-v2"

--- a/.machine_readable/6a2/PLAYBOOK.a2ml
+++ b/.machine_readable/6a2/PLAYBOOK.a2ml
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
+#
+# PLAYBOOK.a2ml — Operational playbook
+# Runbooks, incident response, deployment procedures.
+
+[metadata]
+version = "0.1.0"
+last-updated = "2026-04-11"
+
+[deployment]
+# method = "gitops"  # gitops | manual | ci-triggered
+# target = "container"  # container | binary | library | wasm
+
+[incident-response]
+# 1. Check .machine_readable/STATE.a2ml for current status
+# 2. Review recent commits and CI results
+# 3. Run `just validate` to check compliance
+# 4. Run `just security` to audit for vulnerabilities
+
+[release-process]
+# 1. Update version in STATE.a2ml, META.a2ml, Justfile
+# 2. Run `just release-preflight` (validate + quality + security + maint-hard-pass)
+# 3. Optional local permission hardening: `just perms-snapshot && just perms-lock`
+# 4. Tag and push
+# 5. Restore local permissions if needed: `just perms-restore`
+# 6. Run `just container-push` if applicable
+
+[maintenance-operations]
+# Baseline audit:
+#   just maint-audit
+# Hard release gate:
+#   just maint-hard-pass
+# Permission audit:
+#   just perms-audit
+
+[rsr-repo-skeleton]
+# Canonical organisation of any RSR-derived repository.
+# Used by tooling, human onboarding, and the scheduled downstream sweep agent.
+# The 5-PR cleanup pattern (below) brings a non-conforming repository into
+# compliance with this skeleton.
+#
+# This section is the single source of truth for "what does an RSR repo look
+# like?". Other docs (TOPOLOGY, AUDIT, etc.) describe the repo at hand;
+# this describes the canonical shape that all RSR repos share.
+
+skeleton-version = "1.0"
+last-updated = "2026-04-30"
+authority-allowlist = ".machine_readable/root-allow.txt"
+enforcement-workflow = ".github/workflows/estate-rules.yml"
+
+# === Required at root ===
+# README.adoc          High-level pitch (project entry point)
+# AUDIT.adoc           Local gate summary (release-readiness)
+# EXPLAINME.adoc       Developer deep-dive (architecture & invariants)
+# 0-AI-MANIFEST.a2ml   AI agent work-allocation policy
+# LICENSE              Repo license (root-bound by convention)
+# CHANGELOG.md         One of the recognised .md exceptions (see below)
+# Justfile             Task runner — thin, imports per-section files from build/just/
+# coordination.k9      Repo-local session binding
+
+# === Required directories ===
+# .github/             CONTRIBUTING.md, CODE_OF_CONDUCT.md, SECURITY.md, workflows/
+# .machine_readable/   AI manifests (0.1-AI-MANIFEST.a2ml), 6a2/ checkpoints,
+#                      contractiles/, configs/, anchors/, policies/, scripts/, svc/
+# build/               contractile.just, flake.nix, guix.scm, Containerfile,
+#                      just/*.just (Justfile section imports)
+# docs/                onboarding/, status/, architecture/, governance/  (all .adoc)
+# session/             dispatch.sh, custom-checks.k9, local-hooks.sh
+# src/                 Project source (Idris2 ABI under abi/, Zig FFI under ffi/)
+# tests/, benches/, examples/, features/, scripts/, verification/, container/
+
+# === Documentation format rule ===
+# `.adoc` is the default for all general docs (TOPOLOGY, READINESS, ROADMAP,
+# TEST-NEEDS, PROOF-NEEDS, PROOF-STATUS, llm-warmup-*, etc.).
+#
+# `.md` is reserved ONLY for files GitHub's community-health rules
+# special-case by name:
+#   CONTRIBUTING.md  CODE_OF_CONDUCT.md  SECURITY.md  CHANGELOG.md
+#
+# Enforcement: `scripts/check-no-md-in-docs.sh` (fails if any *.md under docs/).
+
+# === Banned: ziguage ===
+# V (vlang.io) is banned estate-wide. Replaced by `zig-unified-api-adapter`
+# (16 endpoints + transaction-based firewall gating). Do not introduce
+# zig code, scaffolders, or references. Note that Coq theorem files use
+# the same `.v` extension and are unaffected — the rule looks at content
+# patterns, not the extension.
+#
+# Enforcement: `scripts/check-no-vlang.sh`.
+
+# === Justfile structure (post-split) ===
+# The root Justfile is thin — it holds `set` directives, project metadata
+# variables, and the `default`/`help`/`info` recipes. Each major section
+# lives in its own file under build/just/ and is brought in via `import?`.
+#
+# Imported sections (in the canonical split):
+#   build/just/init.just       INIT recipe (template bootstrap)
+#   build/just/assess.just     self-assess + verify (OpenSSF compliance)
+#   build/just/validate.just   validate-rsr/state/ai-install + aggregate
+#   build/just/proofs.just     proof-check-{all,idris2,lean4,agda,coq},
+#                              proof-scan-dangerous, proof-status
+#   build/just/groove.just     Groove protocol setup (after zig removed)
+#
+# Daily-use recipes (BUILD, TEST, LINT, RUN, DEPS, DOCS, CONTAINER, CI,
+# SECURITY, STATE, GUIX/NIX, MATRIX, VERSION CONTROL, UTILITIES, SESSION)
+# stay in the root Justfile where users expect to find them.
+
+# === 5-PR cleanup pattern ===
+# Apply these branches (in order) to bring a non-conforming downstream repo
+# into compliance with this skeleton:
+#
+# 1. chore/root-cleanup       Relocate root sprawl per root-allow.txt; add
+#                             scripts/check-root-shape.sh; remove stub
+#                             health files shadowed by .github/ versions.
+# 2. chore/remove-zig      Purge zig remnants (gen-v-connector recipe,
+#                             "V-TRIPLE" section header, "V-triple
+#                             connectors" comment in groove.a2ml).
+# 3. chore/md-to-adoc         Port general docs in docs/ from .md to .adoc;
+#                             update validate-template.sh to accept .adoc
+#                             fallbacks.
+# 4. chore/estate-rules-ci    Add scripts/check-no-md-in-docs.sh + check-no-
+#                             vlang.sh + .github/workflows/estate-rules.yml.
+# 5. chore/<repo>-hygiene     Repo-specific drift cleanup (case collisions,
+#                             template-derivation drift in titles, etc.).
+
+# === Reference scripts ===
+# scripts/check-root-shape.sh      Root allowlist validator
+# scripts/check-no-md-in-docs.sh   AsciiDoc-by-default validator
+# scripts/check-no-vlang.sh        zig ban validator
+# scripts/validate-template.sh     Aggregate RSR compliance (workflows, SPDX, etc.)
+
+# === Reference memory entries (for AI agents) ===
+# feedback_adoc_default_md_for_githealth   AsciiDoc-by-default rule
+# feedback_v_lang_banned                   zig ban
+# project_zig_unified_api                  Replacement for v-triple/zig
+# feedback_gh_workflow_scope               OAuth scope for workflow files

--- a/.machine_readable/6a2/STATE.a2ml
+++ b/.machine_readable/6a2/STATE.a2ml
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
+#
+# STATE.a2ml — Project state checkpoint (META-TEMPLATE)
+#
+# This is the STATE file for rsr-template-repo itself.
+# When consumed by a new project, replace {{PLACEHOLDER}} tokens
+# and customize sections below for the target project.
+
+[metadata]
+project = "rsr-template-repo"
+version = "0.2.0"
+last-updated = "2026-02-28"
+status = "active"  # active | paused | archived
+
+[project-context]
+name = "rsr-template-repo"
+purpose = "Canonical RSR-compliant repository template providing scaffolding for all hyperpolymath projects — including CI/CD, AI manifests, ABI/FFI standards, container ecosystem, and governance infrastructure."
+completion-percentage = 95
+
+[position]
+phase = "maintenance"      # design | implementation | testing | maintenance | archived
+maturity = "production"    # experimental | alpha | beta | production | lts
+
+[route-to-mvp]
+milestones = [
+  { name = "Phase 0: Core scaffolding (justfile, CI/CD, .machine_readable)", completion = 100 },
+  { name = "Phase 1: ABI/FFI standard (Idris2/Zig templates)", completion = 100 },
+  { name = "Phase 1b: AI Gatekeeper Protocol (0-AI-MANIFEST.a2ml)", completion = 100 },
+  { name = "Phase 1c: TOPOLOGY.md standard and guide", completion = 100 },
+  { name = "Phase 1d: Maintenance gate (axes, checklist, approach)", completion = 100 },
+  { name = "Phase 1e: Trustfile / contractiles", completion = 100 },
+  { name = "Phase 2: Container ecosystem templates (stapeln)", completion = 100 },
+  { name = "Phase 3: Multi-forge sync hardening", completion = 0 },
+  { name = "Phase 4: Nix/Guix reproducible shells", completion = 50 },
+]
+
+[blockers-and-issues]
+# No active blockers
+
+[critical-next-actions]
+actions = [
+  "Container templates complete — test with `just container-init`",
+  "Validate container templates across wolfi-base and static Chainguard images",
+  "Harden multi-forge sync for GitLab/Bitbucket mirroring edge cases",
+  "Expand Nix/Guix development shell templates",
+]
+
+[maintenance-status]
+last-run-utc = "never"
+last-report = "docs/reports/maintenance/latest.json"
+last-result = "unknown"  # unknown | pass | warn | fail
+open-warnings = 0
+open-failures = 0
+
+[ecosystem]
+part-of = ["RSR Framework", "stapeln ecosystem"]
+depends-on = ["stapeln", "selur-compose", "cerro-torre", "svalinn", "vordr", "k9-svc"]
+
+# ---------------------------------------------------------------------------
+# NOTE FOR CONSUMERS: When using this template to create a new repo, reset
+# the fields above to your project's values and replace all {{PLACEHOLDER}}
+# tokens. The milestones above describe the TEMPLATE's evolution, not yours.
+# ---------------------------------------------------------------------------

--- a/.machine_readable/contractiles/Adjustfile.a2ml
+++ b/.machine_readable/contractiles/Adjustfile.a2ml
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: MPL-2.0
+# Adjustfile — Drift-tolerance contract for rsr-template-repo
+# Author: Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+#
+# Cumulative-drift catchment: tolerance bands + corrective actions.
+# Authority: advisory (Yard) — continue-with-warnings; auto_fix where deterministic.
+# Run with: adjust check
+# Fix with: adjust fix (applies deterministic patches; advisory otherwise)
+
+@abstract:
+Drift tolerances and corrective actions for rsr-template-repo. Unlike
+MUST (hard gate), ADJUST tracks cumulative drift against tolerance bands
+and proposes corrective actions. Advisory — it warns and trends, it does
+not block.
+@end
+
+## Template Drift
+
+### placeholder-drift
+- description: Template placeholders should be replaced when copied
+- tolerance: 0 placeholder markers in copied repos
+- corrective: Search and replace all {{PLACEHOLDER}} markers
+- severity: advisory
+- notes: This check only applies to repos that copied from this template
+
+### template-version-drift
+- description: Template version should match RSR spec version
+- tolerance: Template version matches current RSR spec
+- corrective: Update template to match latest RSR spec
+- severity: advisory
+
+## Documentation Drift
+
+### readme-completeness
+- description: README should document all template features
+- tolerance: README covers all contractiles and directory structure
+- corrective: Update README.adoc with missing sections
+- severity: advisory
+
+### example-accuracy
+- description: Examples in documentation should match actual template content
+- tolerance: All code examples in docs are accurate
+- corrective: Audit and fix examples in documentation
+- severity: advisory
+
+## Structural Drift
+
+### contractile-sync
+- description: All contractiles should have matching a2ml and ncl implementations
+- tolerance: Every .a2ml has a corresponding .ncl
+- corrective: Generate missing .ncl files from .a2ml
+- severity: advisory
+
+### no-broken-symlinks
+- description: No broken symbolic links in template structure
+- tolerance: 0 broken symlinks
+- corrective: Run symlink-check script
+- severity: advisory
+
+## Accessibility Drift
+
+### adoc-not-md
+- description: Template docs should prefer AsciiDoc
+- tolerance: New prose docs are *.adoc
+- corrective: Convert any new *.md to *.adoc
+- severity: advisory
+
+### spdx-header-consistency
+- description: All template files have correct SPDX headers
+- tolerance: 0 files missing SPDX-License-Identifier
+- corrective: Add SPDX headers to files that need them
+- severity: advisory

--- a/.machine_readable/contractiles/Intentfile.a2ml
+++ b/.machine_readable/contractiles/Intentfile.a2ml
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: MPL-2.0
+# Intentfile (A2ML Canonical) — north-star contractile for rsr-template-repo
+# Author: Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+#
+# Paired runner: intend.ncl
+# Verb:          intend
+#
+# Semantics: North-star contractile. Declares BOTH concrete committed
+#            next-actions AND horizon aspirations the project wishes to
+#            become. Two sections share one file because they answer
+#            the same question at different ranges:
+#              [[intents]] — "we WILL do this; track progress"
+#                            status: declared → in_progress → done |
+#                                    deferred | retired
+#              [[wishes]]  — "we WISH this were true; revisit later"
+#                            status: declared → in_progress → achieved |
+#                                    abandoned
+#                            grouped by horizon: near / mid / far.
+#            Non-gating — this is a report, not a gate. See the `must`
+#            contractile for hard gates.
+
+@abstract:
+North-star contractile for rsr-template-repo. This repository is the
+canonical template for Rhodium Standard Repository compliance. It provides
+the scaffold that all hyperpolymath repos should copy and customize.
+@end
+
+## Purpose
+
+The rsr-template-repo serves as the master template for all hyperpolymath
+repositories. It contains the complete set of contractile files, machine-readable
+specifications, and governance documentation that define the Rhodium Standard.
+
+Every new repository in the hyperpolymath estate should be initialized by
+copying this template and substituting the placeholder values with
+repo-specific content.
+
+## Anti-Purpose
+
+This repository is NOT:
+- A general-purpose project scaffold for external use (hyperpolymath-only)
+- A replacement for per-repo customization (all files must be bespoke)
+- A static template that never changes (evolves with RSR spec)
+- A runtime library or framework (build-time only)
+
+## If In Doubt
+
+If you are unsure whether a change is in scope, ask. Sensitive areas:
+- .machine_readable/ contractile definitions
+- RSR specification files
+- Governance templates
+- License policy documents
+
+## Committed Next-Actions
+
+### repo-initialization
+- description: Provide just copy-and-substitute template for new repos
+- probe: test -f scripts/init-repo.sh
+- status: done
+- notes: Run with source scripts/init-repo.sh <new-repo-name>
+
+### contractile-completeness
+- description: Every RSR contractile has an a2ml and ncl implementation
+- probe: ls .machine_readable/contractiles/*.a2ml | wc -l | grep -q "^6$"
+- status: in_progress
+- notes: Currently 6 contractile verbs: intend, must, trust, adjust, bust, dust
+
+### automation-scripts
+- description: All repetitive tasks have just recipes
+- probe: grep -c "^# " Justfile | grep -q "^[6-9][0-9]*$"
+- status: in_progress
+
+## Wishes
+
+### Near Horizon
+
+#### cross-repo-validation
+- description: Tooling to validate all repos against RSR spec
+- horizon: near
+- status: declared
+
+#### automated-substitution
+- description: Script to automate repo-specific substitution in template
+- horizon: near
+- status: declared
+
+### Mid Horizon
+
+#### formal-verification
+- description: Idris2 proofs for all critical contractile invariants
+- horizon: mid
+- status: declared
+
+### Far Horizon
+
+#### ecosystem-visualization
+- description: Interactive graph of all hyperpolymath repos and dependencies
+- horizon: far
+- status: declared

--- a/.machine_readable/contractiles/Justfile
+++ b/.machine_readable/contractiles/Justfile
@@ -1,0 +1,784 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
+#
+# RSR Standard Justfile Template
+# https://just.systems/man/en/
+#
+# Copy this file to new projects and customize the placeholder values.
+#
+# Run `just` to see all available recipes
+# Run `just cookbook` to generate docs/just-cookbook.adoc
+# Run `just combinations` to see matrix recipe options
+
+set shell := ["bash", "-uc"]
+set dotenv-load := true
+set positional-arguments := true
+
+# Import auto-generated contractile recipes (must-check, trust-verify, etc.)
+# Re-generate with: contractile gen-just
+import? "build/contractile.just"
+
+# Project metadata — customize these
+project := "rsr-template-repo"
+OWNER := "hyperpolymath"
+REPO := "rsr-template-repo"
+version := "0.1.0"
+tier := "infrastructure"  # 1 | 2 | infrastructure
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# DEFAULT & HELP
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Show all available recipes with descriptions
+default:
+    @just --list --unsorted
+
+# Show detailed help for a specific recipe
+help recipe="":
+    #!/usr/bin/env bash
+    if [ -z "{{recipe}}" ]; then
+        just --list --unsorted
+        echo ""
+        echo "Usage: just help <recipe>"
+        echo "       just cookbook     # Generate full documentation"
+        echo "       just combinations # Show matrix recipes"
+    else
+        just --show "{{recipe}}" 2>/dev/null || echo "Recipe '{{recipe}}' not found"
+    fi
+
+# Show this project's info
+info:
+    @echo "Project: {{project}}"
+    @echo "Version: {{version}}"
+    @echo "RSR Tier: {{tier}}"
+    @echo "Recipes: $(just --summary | wc -w)"
+    @[ -f ".machine_readable/STATE.a2ml" ] && grep -oP 'phase\s*=\s*"\K[^"]+' .machine_readable/STATE.a2ml | head -1 | xargs -I{} echo "Phase: {}" || true
+
+# Run Invariant Path overlay tools for this repository
+invariant-path *ARGS:
+    ./scripts/invariant-path.sh {{ARGS}}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# INIT — see build/just/init.just
+# ═══════════════════════════════════════════════════════════════════════════════
+
+import? "build/just/init.just"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# GROOVE PROTOCOL — see build/just/groove.just
+# ═══════════════════════════════════════════════════════════════════════════════
+
+import? "build/just/groove.just"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# PROJECT SELF-ASSESSMENT + OPENSSF COMPLIANCE — see build/just/assess.just
+# ═══════════════════════════════════════════════════════════════════════════════
+
+import? "build/just/assess.just"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# BUILD & COMPILE
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Build the project (debug mode)
+build *args:
+    @echo "Building {{project}} (debug)..."
+    # TODO: Replace with your build command
+    # Examples:
+    #   cargo build {{args}}                    # Rust
+    #   mix compile {{args}}                    # Elixir
+    #   zig build {{args}}                      # Zig
+    #   deno task build {{args}}                # Deno/ReScript
+    @echo "Build complete"
+
+# Build in release mode with optimizations
+build-release *args:
+    @echo "Building {{project}} (release)..."
+    # TODO: Replace with your release build command
+    # Examples:
+    #   cargo build --release {{args}}
+    #   MIX_ENV=prod mix compile {{args}}
+    #   zig build -Doptimize=ReleaseFast {{args}}
+    @echo "Release build complete"
+
+# Build and watch for changes (requires entr or similar)
+build-watch:
+    @echo "Watching for changes..."
+    # TODO: Customize file patterns for your language
+    # Examples:
+    #   find src -name '*.rs' | entr -c just build
+    #   mix compile --force --warnings-as-errors
+    #   deno task dev
+
+# Clean build artifacts [reversible: rebuild with `just build`]
+clean:
+    @echo "Cleaning..."
+    # TODO: Customize for your build system
+    rm -rf target/ _build/ build/ dist/ out/ obj/ bin/
+
+# Deep clean including caches [reversible: rebuild]
+clean-all: clean
+    rm -rf .cache .tmp
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# TEST & QUALITY
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Run all tests
+test *args:
+    @echo "Running tests..."
+    # TODO: Replace with your test command
+    # Examples:
+    #   cargo test {{args}}
+    #   mix test {{args}}
+    #   zig build test {{args}}
+    #   deno test {{args}}
+    @echo "Tests passed!"
+
+# Run tests with verbose output
+test-verbose:
+    @echo "Running tests (verbose)..."
+    # TODO: Replace with verbose test command
+
+# Smoke test
+test-smoke:
+    @echo "Smoke test..."
+    # TODO: Add basic sanity checks
+
+# Run end-to-end tests (full pipeline: build → run → verify)
+e2e:
+    @echo "Running E2E tests..."
+    # TODO: Replace with your E2E test command. Examples:
+    #   bash tests/e2e.sh                    # Shell-based E2E
+    #   npx playwright test                  # Browser E2E
+    #   mix test test/integration/e2e_test.exs  # Elixir E2E
+    #   cargo test --test end_to_end         # Rust E2E
+    @echo "E2E tests passed!"
+
+# Run aspect tests (cross-cutting concern validation)
+aspect:
+    @echo "Running aspect tests..."
+    # TODO: Replace with your aspect test command. Examples:
+    #   bash tests/aspect_tests.sh           # Shell-based aspect tests
+    #   cargo test --test aspects             # Rust aspect tests
+    # Aspect tests validate architectural invariants:
+    #   - Thread safety (mutex in FFI modules)
+    #   - ABI/FFI contract (declarations match exports)
+    #   - SPDX compliance (all files have license headers)
+    #   - No dangerous patterns (believe_me, assert_total, etc.)
+    @echo "Aspect tests passed!"
+
+# Run benchmarks (performance regression detection)
+bench:
+    @echo "Running benchmarks..."
+    # TODO: Replace with your benchmark command. Examples:
+    #   cargo bench                           # Rust criterion
+    #   zig build bench                       # Zig benchmarks
+    #   mix run bench/benchmarks.exs          # Elixir benchee
+    #   deno bench                            # Deno bench
+    @echo "Benchmarks complete!"
+
+# Run readiness tests (Component Readiness Grade: D/C/B)
+readiness:
+    @echo "Running readiness tests..."
+    # TODO: Replace with your readiness test command. Examples:
+    #   cargo test --test readiness -- --nocapture
+    @echo "Readiness tests complete!"
+
+# Print the current CRG grade (reads from READINESS.md '**Current Grade:** X' line)
+crg-grade:
+    @grade=$$(grep -oP '(?<=\*\*Current Grade:\*\* )[A-FX]' READINESS.md 2>/dev/null | head -1); \
+    [ -z "$$grade" ] && grade="X"; \
+    echo "$$grade"
+
+# Print a shields.io CRG badge for embedding in README files
+# Looks for '**Current Grade:** X' in READINESS.md; falls back to X
+crg-badge:
+    @grade=$$(grep -oP '(?<=\*\*Current Grade:\*\* )[A-FX]' READINESS.md 2>/dev/null | head -1); \
+    [ -z "$$grade" ] && grade="X"; \
+    case "$$grade" in \
+      A) color="brightgreen" ;; \
+      B) color="green" ;; \
+      C) color="yellow" ;; \
+      D) color="orange" ;; \
+      E) color="red" ;; \
+      F) color="critical" ;; \
+      *) color="lightgrey" ;; \
+    esac; \
+    echo "[![CRG $$grade](https://img.shields.io/badge/CRG-$$grade-$$color?style=flat-square)](https://github.com/hyperpolymath/standards/tree/main/component-readiness-grades)"
+
+# Run the full merge-requirement test suite (ALL categories)
+# Per STANDING rule: P2P + E2E + aspect + execution + lifecycle + bench
+test-all: test e2e aspect bench readiness
+    @echo "All test categories passed — safe to merge!"
+
+# Run all quality checks
+quality: fmt-check lint test
+    @echo "All quality checks passed!"
+
+# Fix all auto-fixable issues [reversible: git checkout]
+fix: fmt
+    @echo "Fixed all auto-fixable issues"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# LINT & FORMAT
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Format all source files [reversible: git checkout]
+fmt:
+    @echo "Formatting source files..."
+    # TODO: Replace with your formatter
+    # Examples:
+    #   cargo fmt
+    #   mix format
+    #   gleam format
+    #   deno fmt
+
+# Check formatting without changes
+fmt-check:
+    @echo "Checking formatting..."
+    # TODO: Replace with your format check
+    # Examples:
+    #   cargo fmt --check
+    #   mix format --check-formatted
+    #   gleam format --check
+
+# Run linter
+lint:
+    @echo "Linting source files..."
+    # TODO: Replace with your linter
+    # Examples:
+    #   cargo clippy -- -D warnings
+    #   mix credo --strict
+    #   gleam check
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# RUN & EXECUTE
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Run the application
+run *args: build
+    # TODO: Replace with your run command
+    echo "Run not configured yet"
+
+# Run with verbose output
+run-verbose *args: build
+    # TODO: Replace with verbose run command
+    echo "Run not configured yet"
+
+# Install to user path
+install: build-release
+    @echo "Installing {{project}}..."
+    # TODO: Replace with your install command
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# DEPENDENCIES
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Install/check all dependencies
+deps:
+    @echo "Checking dependencies..."
+    # TODO: Replace with your dependency check
+    # Examples:
+    #   cargo check
+    #   mix deps.get
+    #   gleam deps download
+    @echo "All dependencies satisfied"
+
+# Audit dependencies for vulnerabilities
+deps-audit:
+    @echo "Auditing for vulnerabilities..."
+    # TODO: Replace with your audit command
+    # Examples:
+    #   cargo audit
+    #   mix audit
+    @command -v trivy >/dev/null && trivy fs --severity HIGH,CRITICAL --quiet . || true
+    @echo "Audit complete"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# DOCUMENTATION
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Generate all documentation
+docs:
+    @mkdir -p docs/generated docs/man
+    just cookbook
+    just man
+    @echo "Documentation generated in docs/"
+
+# Generate justfile cookbook documentation
+cookbook:
+    #!/usr/bin/env bash
+    mkdir -p docs
+    OUTPUT="docs/just-cookbook.adoc"
+    echo "= {{project}} Justfile Cookbook" > "$OUTPUT"
+    echo ":toc: left" >> "$OUTPUT"
+    echo ":toclevels: 3" >> "$OUTPUT"
+    echo "" >> "$OUTPUT"
+    echo "Generated: $(date -Iseconds)" >> "$OUTPUT"
+    echo "" >> "$OUTPUT"
+    echo "== Recipes" >> "$OUTPUT"
+    echo "" >> "$OUTPUT"
+    just --list --unsorted | while read -r line; do
+        if [[ "$line" =~ ^[[:space:]]+([a-z_-]+) ]]; then
+            recipe="${BASH_REMATCH[1]}"
+            echo "=== $recipe" >> "$OUTPUT"
+            echo "" >> "$OUTPUT"
+            echo "[source,bash]" >> "$OUTPUT"
+            echo "----" >> "$OUTPUT"
+            echo "just $recipe" >> "$OUTPUT"
+            echo "----" >> "$OUTPUT"
+            echo "" >> "$OUTPUT"
+        fi
+    done
+    echo "Generated: $OUTPUT"
+
+# Generate man page
+man:
+    #!/usr/bin/env bash
+    mkdir -p docs/man
+    cat > docs/man/{{project}}.1 << EOF
+    .TH {{project}} 1 "$(date +%Y-%m-%d)" "{{version}}" "{{project}} Manual"
+    .SH NAME
+    {{project}} \- RSR-compliant project
+    .SH SYNOPSIS
+    .B just
+    [recipe] [args...]
+    .SH DESCRIPTION
+    RSR (Rhodium Standard Repository) project managed with just.
+    .SH AUTHOR
+    $(git config user.name 2>/dev/null || echo "Author") <$(git config user.email 2>/dev/null || echo "email")>
+    EOF
+    echo "Generated: docs/man/{{project}}.1"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# CONTAINERS (stapeln ecosystem — Podman + Chainguard Wolfi)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Initialise container templates — substitute placeholders with project values
+container-init:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    if [ ! -d "container" ]; then
+        echo "Error: container/ directory not found."
+        echo "This repo may not have been created from rsr-template-repo."
+        exit 1
+    fi
+
+    echo "=== Container Template Initialisation ==="
+    echo ""
+
+    # Load RSR defaults if available
+    DEFAULTS="${XDG_CONFIG_HOME:-$HOME/.config}/rsr/defaults"
+    if [ -f "$DEFAULTS" ]; then
+        echo "Loading defaults from $DEFAULTS"
+        # shellcheck source=/dev/null
+        source "$DEFAULTS"
+        echo ""
+    fi
+
+    # Prompt for container-specific values
+    read -rp "Service name (e.g. my-api) [{{project}}]: " _SERVICE_NAME
+    SERVICE_NAME="${_SERVICE_NAME:-{{project}}}"
+
+    read -rp "Primary port [8080]: " _PORT
+    PORT="${_PORT:-8080}"
+
+    read -rp "Container registry [ghcr.io/${OWNER:-{{OWNER}}}]: " _REGISTRY
+    REGISTRY="${_REGISTRY:-ghcr.io/${OWNER:-{{OWNER}}}}"
+
+    echo ""
+    echo "  Service: $SERVICE_NAME"
+    echo "  Port:    $PORT"
+    echo "  Registry: $REGISTRY"
+    echo ""
+    read -rp "Proceed? [Y/n] " CONFIRM
+    [[ "${CONFIRM:-Y}" =~ ^[Nn] ]] && echo "Aborted." && exit 0
+
+    echo ""
+    echo "Replacing container placeholders..."
+
+    # Brace tokens as variables (hex escapes avoid just interpolation)
+    LB=$(printf '\x7b\x7b')
+    RB=$(printf '\x7d\x7d')
+
+    SED_ARGS=(
+        -e "s|${LB}SERVICE_NAME${RB}|${SERVICE_NAME}|g"
+        -e "s|${LB}PORT${RB}|${PORT}|g"
+        -e "s|${LB}REGISTRY${RB}|${REGISTRY}|g"
+    )
+
+    find container/ -type f | while read -r file; do
+        if file --brief "$file" | grep -qi 'text\|ascii\|utf'; then
+            sed -i "${SED_ARGS[@]}" "$file"
+        fi
+    done
+
+    echo "Container templates initialised."
+    echo ""
+    echo "Next steps:"
+    echo "  1. Edit container/Containerfile — add your build commands"
+    echo "  2. Edit container/entrypoint.sh — set your application binary"
+    echo "  3. Review container/compose.toml — adjust services and volumes"
+    echo "  4. Build: just container-build"
+
+# Build container image via cerro-torre pipeline
+container-build *args:
+    #!/usr/bin/env bash
+    if [ -f "container/ct-build.sh" ]; then
+        cd container && ./ct-build.sh {{args}}
+    elif [ -f "container/Containerfile" ]; then
+        podman build -t {{project}}:latest -f container/Containerfile .
+    elif [ -f "build/Containerfile" ]; then
+        podman build -t {{project}}:latest -f build/Containerfile .
+    elif [ -f "Containerfile" ]; then
+        podman build -t {{project}}:latest -f Containerfile .
+    else
+        echo "No Containerfile found in container/, build/, or project root"
+        exit 1
+    fi
+
+# Verify compose configuration
+container-verify:
+    #!/usr/bin/env bash
+    if [ ! -f "container/compose.toml" ]; then
+        echo "No container/compose.toml found"
+        exit 1
+    fi
+    cd container
+    if command -v selur-compose &>/dev/null; then
+        selur-compose verify
+    else
+        echo "selur-compose not found, falling back to podman compose"
+        podman compose --file compose.toml config
+    fi
+
+# Start container stack
+container-up *args:
+    #!/usr/bin/env bash
+    if [ ! -f "container/compose.toml" ]; then
+        echo "No container/compose.toml found"
+        exit 1
+    fi
+    cd container
+    if command -v selur-compose &>/dev/null; then
+        selur-compose up {{args}}
+    else
+        podman compose --file compose.toml up {{args}}
+    fi
+
+# Stop container stack
+container-down:
+    #!/usr/bin/env bash
+    cd container 2>/dev/null || { echo "No container/ directory"; exit 1; }
+    if command -v selur-compose &>/dev/null; then
+        selur-compose down
+    else
+        podman compose --file compose.toml down
+    fi
+
+# Sign and verify container bundle (build + pack + sign + verify)
+container-sign:
+    #!/usr/bin/env bash
+    if [ -f "container/ct-build.sh" ]; then
+        cd container && ./ct-build.sh
+    else
+        echo "No container/ct-build.sh found"
+        exit 1
+    fi
+
+# Push signed bundle to registry
+container-push:
+    #!/usr/bin/env bash
+    if [ -f "container/ct-build.sh" ]; then
+        cd container && ./ct-build.sh --push
+    else
+        echo "No container/ct-build.sh found — falling back to podman push"
+        podman push {{project}}:latest
+    fi
+
+# Run container interactively (for debugging)
+container-run *args:
+    podman run --rm -it {{project}}:latest {{args}}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# CI & AUTOMATION
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Run full CI pipeline locally
+ci: deps quality
+    @echo "CI pipeline complete!"
+
+# Install git hooks
+install-hooks:
+    @mkdir -p .git/hooks
+    @cat > .git/hooks/pre-commit << 'HOOKEOF'
+    #!/bin/bash
+    just fmt-check || exit 1
+    just lint || exit 1
+    just assail || exit 1
+    HOOKEOF
+    @chmod +x .git/hooks/pre-commit
+    @echo "Git hooks installed"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# SECURITY
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Run security audit
+security: deps-audit
+    @echo "=== Security Audit ==="
+    @command -v trivy >/dev/null && trivy fs --severity HIGH,CRITICAL . || true
+    @echo "Security audit complete"
+
+# Generate SBOM
+sbom:
+    @mkdir -p docs/security
+    @command -v syft >/dev/null && syft . -o spdx-json > docs/security/sbom.spdx.json || echo "syft not found"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# VALIDATION & COMPLIANCE — see build/just/validate.just
+# ═══════════════════════════════════════════════════════════════════════════════
+
+import? "build/just/validate.just"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# STATE MANAGEMENT
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Update STATE.a2ml timestamp
+state-touch:
+    @if [ -f ".machine_readable/STATE.a2ml" ]; then \
+        sed -i 's/last-updated = "[^"]*"/last-updated = "'"$(date +%Y-%m-%d)"'"/' .machine_readable/STATE.a2ml && \
+        echo "STATE.a2ml timestamp updated"; \
+    fi
+
+# Show current phase from STATE.a2ml
+state-phase:
+    @grep -oP 'phase\s*=\s*"\K[^"]+' .machine_readable/STATE.a2ml 2>/dev/null | head -1 || echo "unknown"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# GUIX & NIX
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Enter Guix development shell (primary)
+guix-shell:
+    guix shell -D -f guix.scm
+
+# Build with Guix
+guix-build:
+    guix build -f guix.scm
+
+# Enter Nix development shell (fallback)
+nix-shell:
+    @if [ -f "flake.nix" ]; then nix develop; else echo "No flake.nix"; fi
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# HYBRID AUTOMATION
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Run local automation tasks
+automate task="all":
+    #!/usr/bin/env bash
+    case "{{task}}" in
+        all) just fmt && just lint && just test && just docs && just state-touch ;;
+        cleanup) just clean && find . -name "*.orig" -delete && find . -name "*~" -delete ;;
+        update) just deps && just validate ;;
+        *) echo "Unknown: {{task}}. Use: all, cleanup, update" && exit 1 ;;
+    esac
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# COMBINATORIC MATRIX RECIPES
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Build matrix: [debug|release] x [target] x [features]
+build-matrix mode="debug" target="" features="":
+    @echo "Build matrix: mode={{mode}} target={{target}} features={{features}}"
+
+# Test matrix: [unit|integration|e2e|all] x [verbosity] x [parallel]
+test-matrix suite="unit" verbosity="normal" parallel="true":
+    @echo "Test matrix: suite={{suite}} verbosity={{verbosity}} parallel={{parallel}}"
+
+# Container matrix: [build|run|push|shell|scan] x [registry] x [tag]
+container-matrix action="build" registry="ghcr.io/{{OWNER}}" tag="latest":
+    @echo "Container matrix: action={{action}} registry={{registry}} tag={{tag}}"
+
+# CI matrix: [lint|test|build|security|all] x [quick|full]
+ci-matrix stage="all" depth="quick":
+    @echo "CI matrix: stage={{stage}} depth={{depth}}"
+
+# Show all matrix combinations
+combinations:
+    @echo "=== Combinatoric Matrix Recipes ==="
+    @echo ""
+    @echo "Build Matrix: just build-matrix [debug|release] [target] [features]"
+    @echo "Test Matrix:  just test-matrix [unit|integration|e2e|all] [verbosity] [parallel]"
+    @echo "Container:    just container-matrix [build|run|push|shell|scan] [registry] [tag]"
+    @echo "CI Matrix:    just ci-matrix [lint|test|build|security|all] [quick|full]"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# VERSION CONTROL
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Show git status
+status:
+    @git status --short
+
+# Show recent commits
+log count="20":
+    @git log --oneline -{{count}}
+
+# Generate CHANGELOG.md with git-cliff
+changelog:
+    @command -v git-cliff >/dev/null || { echo "git-cliff not found — install: cargo install git-cliff"; exit 1; }
+    git cliff --config .machine_readable/configs/git-cliff/cliff.toml --output CHANGELOG.md
+    @echo "Generated CHANGELOG.md"
+
+# Preview changelog for unreleased commits (does not write)
+changelog-preview:
+    @command -v git-cliff >/dev/null || { echo "git-cliff not found — install: cargo install git-cliff"; exit 1; }
+    git cliff --config .machine_readable/configs/git-cliff/cliff.toml --unreleased --strip header
+
+# Tag a new release (usage: just release-tag 1.2.3)
+release-tag version:
+    #!/usr/bin/env bash
+    TAG="v{{version}}"
+    if git rev-parse "$TAG" >/dev/null 2>&1; then
+        echo "Tag $TAG already exists"
+        exit 1
+    fi
+    just changelog
+    git add CHANGELOG.md
+    git commit -m "chore(release): prepare $TAG"
+    git tag -a "$TAG" -m "Release $TAG"
+    echo "Created tag $TAG — push with: git push origin main --tags"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# UTILITIES
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Count lines of code
+loc:
+    @find . \( -name "*.rs" -o -name "*.ex" -o -name "*.exs" -o -name "*.res" -o -name "*.gleam" -o -name "*.zig" -o -name "*.idr" -o -name "*.hs" -o -name "*.ncl" -o -name "*.scm" -o -name "*.adb" -o -name "*.ads" \) -not -path './target/*' -not -path './_build/*' 2>/dev/null | xargs wc -l 2>/dev/null | tail -1 || echo "0"
+
+# Show TODO comments
+todos:
+    @grep -rn "TODO\|FIXME\|HACK\|XXX" --include="*.rs" --include="*.ex" --include="*.res" --include="*.gleam" --include="*.zig" --include="*.idr" --include="*.hs" . 2>/dev/null || echo "No TODOs"
+
+# Open in editor
+edit:
+    ${EDITOR:-code} .
+
+# Run high-rigor security assault using panic-attacker
+maint-assault:
+    @./.machine_readable/scripts/maintenance/maint-assault.sh
+
+# Run panic-attacker pre-commit scan (foundational floor-raise requirement)
+assail:
+    @command -v panic-attack >/dev/null 2>&1 && panic-attack assail . || echo "WARN: panic-attack not found — install from https://github.com/hyperpolymath/panic-attacker"
+
+
+# Self-diagnostic — checks dependencies, permissions, paths
+doctor:
+    @echo "Running diagnostics for rsr-template-repo..."
+    @echo "Checking required tools..."
+    @command -v just >/dev/null 2>&1 && echo "  [OK] just" || echo "  [FAIL] just not found"
+    @command -v git >/dev/null 2>&1 && echo "  [OK] git" || echo "  [FAIL] git not found"
+    @echo "Checking for hardcoded paths..."
+    @grep -rn '$HOME\|$ECLIPSE_DIR' --include='*.rs' --include='*.ex' --include='*.res' --include='*.gleam' --include='*.sh' . 2>/dev/null | head -5 || echo "  [OK] No hardcoded paths"
+    @echo "Diagnostics complete."
+
+# Guided tour of key features
+tour:
+    @echo "=== rsr-template-repo Tour ==="
+    @echo ""
+    @echo "1. Project structure:"
+    @ls -la
+    @echo ""
+    @echo "2. Available commands: just --list"
+    @echo ""
+    @echo "3. Read README.adoc for full overview"
+    @echo "4. Read EXPLAINME.adoc for architecture decisions"
+    @echo "5. Run 'just doctor' to check your setup"
+    @echo ""
+    @echo "Tour complete! Try 'just --list' to see all available commands."
+
+# Open feedback channel with diagnostic context
+help-me:
+    @echo "=== rsr-template-repo Help ==="
+    @echo "Platform: $(uname -s) $(uname -m)"
+    @echo "Shell: $SHELL"
+    @echo ""
+    @echo "To report an issue:"
+    @echo "  https://github.com/hyperpolymath/rsr-template-repo/issues/new"
+    @echo ""
+    @echo "Include the output of 'just doctor' in your report."
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# FORMAL VERIFICATION (PROOFS) — see build/just/proofs.just
+# ═══════════════════════════════════════════════════════════════════════════════
+
+import? "build/just/proofs.just"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# SESSION MANAGEMENT (THIN BINDINGS TO CENTRAL STANDARDS)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Show canonical session-management command model
+session-help:
+    @echo "Canonical command model:"
+    @echo "  intake repo <path>"
+    @echo "  checkpoint change <path>"
+    @echo "  verify maintenance <path>"
+    @echo "  verify substantial <path>"
+    @echo "  verify release <path>"
+    @echo "  close planned <path>"
+    @echo "  close urgent <path>"
+    @echo "  recover repo <path>"
+    @echo "  handover full <path>"
+    @echo "  handover split <path>"
+    @echo "  handover model <path>"
+    @echo "  handover human <path>"
+    @echo ""
+    @echo "Use Just aliases below (thin wrappers around ./session/dispatch.sh)."
+
+# Canonical aliases (friendly recipe names that map to canonical commands)
+intake-repo path=".":
+    @./session/dispatch.sh intake repo "{{path}}"
+
+checkpoint-change path=".":
+    @./session/dispatch.sh checkpoint change "{{path}}"
+
+verify-maintenance path=".":
+    @./session/dispatch.sh verify maintenance "{{path}}"
+
+verify-substantial path=".":
+    @./session/dispatch.sh verify substantial "{{path}}"
+
+verify-release path=".":
+    @./session/dispatch.sh verify release "{{path}}"
+
+close-planned path=".":
+    @./session/dispatch.sh close planned "{{path}}"
+
+close-urgent path=".":
+    @./session/dispatch.sh close urgent "{{path}}"
+
+recover-repo path=".":
+    @./session/dispatch.sh recover repo "{{path}}"
+
+handover-full path=".":
+    @./session/dispatch.sh handover full "{{path}}"
+
+handover-split path=".":
+    @./session/dispatch.sh handover split "{{path}}"
+
+handover-model path=".":
+    @./session/dispatch.sh handover model "{{path}}"
+
+handover-human path=".":
+    @./session/dispatch.sh handover human "{{path}}"
+
+secret-scan-trufflehog:
+    @command -v trufflehog >/dev/null && trufflehog filesystem . --only-verified || true

--- a/.machine_readable/contractiles/Mustfile.a2ml
+++ b/.machine_readable/contractiles/Mustfile.a2ml
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: MPL-2.0
+# Mustfile — Physical state contract for rsr-template-repo
+# Author: Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+#
+# What MUST be true about this repository. Hard requirements.
+# Run with: must check
+# Fix with: must fix (where a deterministic fix exists)
+
+@abstract:
+Physical-state invariants for rsr-template-repo. This is the canonical
+RSR template repository. These are hard requirements — CI and pre-commit
+hooks fail if any check fails.
+@end
+
+## File Presence
+
+### license-present
+- description: LICENSE file must exist
+- run: test -f LICENSE
+- severity: critical
+
+### readme-present
+- description: README.adoc must exist
+- run: test -f README.adoc
+- severity: critical
+
+### security-policy
+- description: SECURITY.md must exist
+- run: test -f SECURITY.md
+- severity: critical
+
+### ai-manifest
+- description: 0-AI-MANIFEST.a2ml must exist
+- run: test -f 0-AI-MANIFEST.a2ml
+- severity: critical
+
+### governance-docs
+- description: GOVERNANCE.adoc, MAINTAINERS.adoc, CODEOWNERS must exist
+- run: test -f GOVERNANCE.adoc && test -f MAINTAINERS.adoc && test -f .github/CODEOWNERS
+- severity: critical
+
+### machine-readable-dir
+- description: .machine_readable/ directory must exist
+- run: test -d .machine_readable
+- severity: critical
+
+## Directory Structure
+
+### contractiles-complete
+- description: All required contractile directories exist
+- run: test -d .machine_readable/contractiles && test -d .machine_readable/contractiles/bust && test -d .machine_readable/contractiles/dust
+- severity: critical
+
+### contractiles-files-present
+- description: All four primary contractile files exist
+- run: test -f .machine_readable/contractiles/Intentfile.a2ml && test -f .machine_readable/contractiles/Mustfile.a2ml && test -f .machine_readable/contractiles/Trustfile.a2ml && test -f .machine_readable/contractiles/Adjustfile.a2ml
+- severity: critical
+
+### bust-dust-files-present
+- description: Bustfile and Dustfile exist in their directories
+- run: test -f .machine_readable/contractiles/bust/Bustfile.a2ml && test -f .machine_readable/contractiles/dust/Dustfile.a2ml
+- severity: critical
+
+### six-directory-present
+- description: 6a2 directory exists with required files
+- run: test -d .machine_readable/6a2 && test -f .machine_readable/6a2/META.a2ml && test -f .machine_readable/6a2/ECOSYSTEM.a2ml && test -f .machine_readable/6a2/STATE.a2ml && test -f .machine_readable/6a2/PLAYBOOK.a2ml && test -f .machine_readable/6a2/AGENTIC.a2ml && test -f .machine_readable/6a2/NEUROSYM.a2ml
+- severity: critical
+
+### anchors-directory
+- description: anchors directory exists in 6a2
+- run: test -d .machine_readable/6a2/anchors
+- severity: warning
+
+### self-validating-structure
+- description: self-validating directory has k9-svc and examples
+- run: test -d .machine_readable/self-validating && test -d .machine_readable/self-validating/k9-svc && test -d .machine_readable/self-validating/examples
+- severity: warning
+
+## Template Integrity
+
+### no-placeholder-values
+- description: No placeholder values remain in template files
+- run: test -z "$(grep -r '{{' .machine_readable/contractiles/ 2>/dev/null)"
+- severity: critical
+- notes: All placeholders must be substituted when copying this template
+
+### template-readonly
+- description: Template marker files are not modified
+- run: grep -q 'RSR_TEMPLATE_DO_NOT_EDIT' .machine_readable/0.1-AI-MANIFEST.a2ml
+- severity: warning
+
+## Git State
+
+### no-untracked-contractiles
+- description: All contractile files are tracked in git
+- run: test -z "$(git ls-files -o --exclude-standard .machine_readable/contractiles/ 2>/dev/null)"
+- severity: critical
+
+### signed-commits
+- description: All commits must be signed
+- run: git verify-commit HEAD
+- severity: critical

--- a/.machine_readable/contractiles/Trustfile.a2ml
+++ b/.machine_readable/contractiles/Trustfile.a2ml
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: MPL-2.0
+# Trustfile — Trust boundaries and integrity invariants for rsr-template-repo
+# Author: Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+#
+# Defines what LLM/SLM agents are trusted to do without asking, and
+# integrity invariants that verify the repo has not been tampered with.
+
+@abstract:
+Trust boundaries and integrity checks for rsr-template-repo. This file
+combines the trust-level definitions from the original TRUST.contractile
+with the integrity invariants from the old Trustfile.a2ml. It defines
+what AI agents may do autonomously and what requires human approval,
+plus checks that verify repository integrity.
+@end
+
+## Trust Levels
+
+The rsr-template-repo operates at trust level: maximal
+
+Trust levels:
+- maximal:    Agent may read, build, test, lint, format, heal freely.
+             Only destructive/external actions require approval.
+- standard:   Agent may read and build. Test/lint need approval.
+- restricted: Agent may read only. All modifications need approval.
+- minimal:    Agent may read specific files only. Everything else blocked.
+
+Current trust level: maximal
+
+## Integrity Invariants
+
+### Secrets
+
+#### no-secrets-committed
+- description: No credential files in repo
+- run: test ! -f .env && test ! -f credentials.json && test ! -f .env.local && test ! -f .env.production
+- severity: critical
+
+#### no-private-keys
+- description: No private key files committed
+- run: "! find . -name '*.pem' -o -name '*.key' -o -name 'id_rsa' -o -name 'id_ed25519' 2>/dev/null | grep -v node_modules | head -1 | grep -q ."
+- severity: critical
+
+#### no-tokens-in-source
+- description: No hardcoded API tokens in source
+- run: "! grep -rE '(api[_-]?key|secret|token|password)\s*[:=]\s*[\"'\\''][A-Za-z0-9]{16,}' --include='*.js' --include='*.ts' --include='*.res' --include='*.py' . 2>/dev/null | grep -v node_modules | head -1 | grep -q ."
+- severity: critical
+
+## Provenance
+
+#### author-correct
+- description: Git author matches expected identity
+- run: "git log -1 --format='%ae' | grep -qE '(hyperpolymath|j\\.d\\.a\\.jewell)'"
+- severity: warning
+
+#### license-content
+- description: LICENSE contains expected identifier
+- run: grep -q 'PMPL\|MPL\|MIT\|Apache\|LGPL' LICENSE
+- severity: warning
+
+## Template-Specific Trust
+
+### template-files-readonly
+- description: Template scaffold files should not be modified except by maintainer
+- run: test -z "$(git status --short .machine_readable/ 2>/dev/null | grep -v '^??' || true)"
+- severity: advisory
+- notes: Changes to template files require careful review
+
+### trust-deny-areas
+- description: Sensitive areas from INTENT.contractile require explicit approval
+- run: echo "Check .machine_readable/ contractiles and governance docs"
+- severity: advisory
+- areas:
+  - .machine_readable/
+  - GOVERNANCE.adoc
+  - MAINTAINERS.adoc
+  - .github/CODEOWNERS
+
+## Container Security
+
+#### container-images-pinned
+- description: Containerfile uses pinned base images
+- run: test ! -f Containerfile || grep -q 'cgr.dev\|@sha256:' Containerfile
+- severity: warning
+
+#### no-dockerfile
+- description: No Dockerfile (use Containerfile)
+- run: test ! -f Dockerfile
+- severity: warning

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,784 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
+#
+# RSR Standard Justfile Template
+# https://just.systems/man/en/
+#
+# Copy this file to new projects and customize the placeholder values.
+#
+# Run `just` to see all available recipes
+# Run `just cookbook` to generate docs/just-cookbook.adoc
+# Run `just combinations` to see matrix recipe options
+
+set shell := ["bash", "-uc"]
+set dotenv-load := true
+set positional-arguments := true
+
+# Import auto-generated contractile recipes (must-check, trust-verify, etc.)
+# Re-generate with: contractile gen-just
+import? "build/contractile.just"
+
+# Project metadata — customize these
+project := "rsr-template-repo"
+OWNER := "hyperpolymath"
+REPO := "rsr-template-repo"
+version := "0.1.0"
+tier := "infrastructure"  # 1 | 2 | infrastructure
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# DEFAULT & HELP
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Show all available recipes with descriptions
+default:
+    @just --list --unsorted
+
+# Show detailed help for a specific recipe
+help recipe="":
+    #!/usr/bin/env bash
+    if [ -z "{{recipe}}" ]; then
+        just --list --unsorted
+        echo ""
+        echo "Usage: just help <recipe>"
+        echo "       just cookbook     # Generate full documentation"
+        echo "       just combinations # Show matrix recipes"
+    else
+        just --show "{{recipe}}" 2>/dev/null || echo "Recipe '{{recipe}}' not found"
+    fi
+
+# Show this project's info
+info:
+    @echo "Project: {{project}}"
+    @echo "Version: {{version}}"
+    @echo "RSR Tier: {{tier}}"
+    @echo "Recipes: $(just --summary | wc -w)"
+    @[ -f ".machine_readable/STATE.a2ml" ] && grep -oP 'phase\s*=\s*"\K[^"]+' .machine_readable/STATE.a2ml | head -1 | xargs -I{} echo "Phase: {}" || true
+
+# Run Invariant Path overlay tools for this repository
+invariant-path *ARGS:
+    ./scripts/invariant-path.sh {{ARGS}}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# INIT — see build/just/init.just
+# ═══════════════════════════════════════════════════════════════════════════════
+
+import? "build/just/init.just"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# GROOVE PROTOCOL — see build/just/groove.just
+# ═══════════════════════════════════════════════════════════════════════════════
+
+import? "build/just/groove.just"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# PROJECT SELF-ASSESSMENT + OPENSSF COMPLIANCE — see build/just/assess.just
+# ═══════════════════════════════════════════════════════════════════════════════
+
+import? "build/just/assess.just"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# BUILD & COMPILE
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Build the project (debug mode)
+build *args:
+    @echo "Building {{project}} (debug)..."
+    # TODO: Replace with your build command
+    # Examples:
+    #   cargo build {{args}}                    # Rust
+    #   mix compile {{args}}                    # Elixir
+    #   zig build {{args}}                      # Zig
+    #   deno task build {{args}}                # Deno/ReScript
+    @echo "Build complete"
+
+# Build in release mode with optimizations
+build-release *args:
+    @echo "Building {{project}} (release)..."
+    # TODO: Replace with your release build command
+    # Examples:
+    #   cargo build --release {{args}}
+    #   MIX_ENV=prod mix compile {{args}}
+    #   zig build -Doptimize=ReleaseFast {{args}}
+    @echo "Release build complete"
+
+# Build and watch for changes (requires entr or similar)
+build-watch:
+    @echo "Watching for changes..."
+    # TODO: Customize file patterns for your language
+    # Examples:
+    #   find src -name '*.rs' | entr -c just build
+    #   mix compile --force --warnings-as-errors
+    #   deno task dev
+
+# Clean build artifacts [reversible: rebuild with `just build`]
+clean:
+    @echo "Cleaning..."
+    # TODO: Customize for your build system
+    rm -rf target/ _build/ build/ dist/ out/ obj/ bin/
+
+# Deep clean including caches [reversible: rebuild]
+clean-all: clean
+    rm -rf .cache .tmp
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# TEST & QUALITY
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Run all tests
+test *args:
+    @echo "Running tests..."
+    # TODO: Replace with your test command
+    # Examples:
+    #   cargo test {{args}}
+    #   mix test {{args}}
+    #   zig build test {{args}}
+    #   deno test {{args}}
+    @echo "Tests passed!"
+
+# Run tests with verbose output
+test-verbose:
+    @echo "Running tests (verbose)..."
+    # TODO: Replace with verbose test command
+
+# Smoke test
+test-smoke:
+    @echo "Smoke test..."
+    # TODO: Add basic sanity checks
+
+# Run end-to-end tests (full pipeline: build → run → verify)
+e2e:
+    @echo "Running E2E tests..."
+    # TODO: Replace with your E2E test command. Examples:
+    #   bash tests/e2e.sh                    # Shell-based E2E
+    #   npx playwright test                  # Browser E2E
+    #   mix test test/integration/e2e_test.exs  # Elixir E2E
+    #   cargo test --test end_to_end         # Rust E2E
+    @echo "E2E tests passed!"
+
+# Run aspect tests (cross-cutting concern validation)
+aspect:
+    @echo "Running aspect tests..."
+    # TODO: Replace with your aspect test command. Examples:
+    #   bash tests/aspect_tests.sh           # Shell-based aspect tests
+    #   cargo test --test aspects             # Rust aspect tests
+    # Aspect tests validate architectural invariants:
+    #   - Thread safety (mutex in FFI modules)
+    #   - ABI/FFI contract (declarations match exports)
+    #   - SPDX compliance (all files have license headers)
+    #   - No dangerous patterns (believe_me, assert_total, etc.)
+    @echo "Aspect tests passed!"
+
+# Run benchmarks (performance regression detection)
+bench:
+    @echo "Running benchmarks..."
+    # TODO: Replace with your benchmark command. Examples:
+    #   cargo bench                           # Rust criterion
+    #   zig build bench                       # Zig benchmarks
+    #   mix run bench/benchmarks.exs          # Elixir benchee
+    #   deno bench                            # Deno bench
+    @echo "Benchmarks complete!"
+
+# Run readiness tests (Component Readiness Grade: D/C/B)
+readiness:
+    @echo "Running readiness tests..."
+    # TODO: Replace with your readiness test command. Examples:
+    #   cargo test --test readiness -- --nocapture
+    @echo "Readiness tests complete!"
+
+# Print the current CRG grade (reads from READINESS.md '**Current Grade:** X' line)
+crg-grade:
+    @grade=$$(grep -oP '(?<=\*\*Current Grade:\*\* )[A-FX]' READINESS.md 2>/dev/null | head -1); \
+    [ -z "$$grade" ] && grade="X"; \
+    echo "$$grade"
+
+# Print a shields.io CRG badge for embedding in README files
+# Looks for '**Current Grade:** X' in READINESS.md; falls back to X
+crg-badge:
+    @grade=$$(grep -oP '(?<=\*\*Current Grade:\*\* )[A-FX]' READINESS.md 2>/dev/null | head -1); \
+    [ -z "$$grade" ] && grade="X"; \
+    case "$$grade" in \
+      A) color="brightgreen" ;; \
+      B) color="green" ;; \
+      C) color="yellow" ;; \
+      D) color="orange" ;; \
+      E) color="red" ;; \
+      F) color="critical" ;; \
+      *) color="lightgrey" ;; \
+    esac; \
+    echo "[![CRG $$grade](https://img.shields.io/badge/CRG-$$grade-$$color?style=flat-square)](https://github.com/hyperpolymath/standards/tree/main/component-readiness-grades)"
+
+# Run the full merge-requirement test suite (ALL categories)
+# Per STANDING rule: P2P + E2E + aspect + execution + lifecycle + bench
+test-all: test e2e aspect bench readiness
+    @echo "All test categories passed — safe to merge!"
+
+# Run all quality checks
+quality: fmt-check lint test
+    @echo "All quality checks passed!"
+
+# Fix all auto-fixable issues [reversible: git checkout]
+fix: fmt
+    @echo "Fixed all auto-fixable issues"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# LINT & FORMAT
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Format all source files [reversible: git checkout]
+fmt:
+    @echo "Formatting source files..."
+    # TODO: Replace with your formatter
+    # Examples:
+    #   cargo fmt
+    #   mix format
+    #   gleam format
+    #   deno fmt
+
+# Check formatting without changes
+fmt-check:
+    @echo "Checking formatting..."
+    # TODO: Replace with your format check
+    # Examples:
+    #   cargo fmt --check
+    #   mix format --check-formatted
+    #   gleam format --check
+
+# Run linter
+lint:
+    @echo "Linting source files..."
+    # TODO: Replace with your linter
+    # Examples:
+    #   cargo clippy -- -D warnings
+    #   mix credo --strict
+    #   gleam check
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# RUN & EXECUTE
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Run the application
+run *args: build
+    # TODO: Replace with your run command
+    echo "Run not configured yet"
+
+# Run with verbose output
+run-verbose *args: build
+    # TODO: Replace with verbose run command
+    echo "Run not configured yet"
+
+# Install to user path
+install: build-release
+    @echo "Installing {{project}}..."
+    # TODO: Replace with your install command
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# DEPENDENCIES
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Install/check all dependencies
+deps:
+    @echo "Checking dependencies..."
+    # TODO: Replace with your dependency check
+    # Examples:
+    #   cargo check
+    #   mix deps.get
+    #   gleam deps download
+    @echo "All dependencies satisfied"
+
+# Audit dependencies for vulnerabilities
+deps-audit:
+    @echo "Auditing for vulnerabilities..."
+    # TODO: Replace with your audit command
+    # Examples:
+    #   cargo audit
+    #   mix audit
+    @command -v trivy >/dev/null && trivy fs --severity HIGH,CRITICAL --quiet . || true
+    @echo "Audit complete"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# DOCUMENTATION
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Generate all documentation
+docs:
+    @mkdir -p docs/generated docs/man
+    just cookbook
+    just man
+    @echo "Documentation generated in docs/"
+
+# Generate justfile cookbook documentation
+cookbook:
+    #!/usr/bin/env bash
+    mkdir -p docs
+    OUTPUT="docs/just-cookbook.adoc"
+    echo "= {{project}} Justfile Cookbook" > "$OUTPUT"
+    echo ":toc: left" >> "$OUTPUT"
+    echo ":toclevels: 3" >> "$OUTPUT"
+    echo "" >> "$OUTPUT"
+    echo "Generated: $(date -Iseconds)" >> "$OUTPUT"
+    echo "" >> "$OUTPUT"
+    echo "== Recipes" >> "$OUTPUT"
+    echo "" >> "$OUTPUT"
+    just --list --unsorted | while read -r line; do
+        if [[ "$line" =~ ^[[:space:]]+([a-z_-]+) ]]; then
+            recipe="${BASH_REMATCH[1]}"
+            echo "=== $recipe" >> "$OUTPUT"
+            echo "" >> "$OUTPUT"
+            echo "[source,bash]" >> "$OUTPUT"
+            echo "----" >> "$OUTPUT"
+            echo "just $recipe" >> "$OUTPUT"
+            echo "----" >> "$OUTPUT"
+            echo "" >> "$OUTPUT"
+        fi
+    done
+    echo "Generated: $OUTPUT"
+
+# Generate man page
+man:
+    #!/usr/bin/env bash
+    mkdir -p docs/man
+    cat > docs/man/{{project}}.1 << EOF
+    .TH {{project}} 1 "$(date +%Y-%m-%d)" "{{version}}" "{{project}} Manual"
+    .SH NAME
+    {{project}} \- RSR-compliant project
+    .SH SYNOPSIS
+    .B just
+    [recipe] [args...]
+    .SH DESCRIPTION
+    RSR (Rhodium Standard Repository) project managed with just.
+    .SH AUTHOR
+    $(git config user.name 2>/dev/null || echo "Author") <$(git config user.email 2>/dev/null || echo "email")>
+    EOF
+    echo "Generated: docs/man/{{project}}.1"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# CONTAINERS (stapeln ecosystem — Podman + Chainguard Wolfi)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Initialise container templates — substitute placeholders with project values
+container-init:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    if [ ! -d "container" ]; then
+        echo "Error: container/ directory not found."
+        echo "This repo may not have been created from rsr-template-repo."
+        exit 1
+    fi
+
+    echo "=== Container Template Initialisation ==="
+    echo ""
+
+    # Load RSR defaults if available
+    DEFAULTS="${XDG_CONFIG_HOME:-$HOME/.config}/rsr/defaults"
+    if [ -f "$DEFAULTS" ]; then
+        echo "Loading defaults from $DEFAULTS"
+        # shellcheck source=/dev/null
+        source "$DEFAULTS"
+        echo ""
+    fi
+
+    # Prompt for container-specific values
+    read -rp "Service name (e.g. my-api) [{{project}}]: " _SERVICE_NAME
+    SERVICE_NAME="${_SERVICE_NAME:-{{project}}}"
+
+    read -rp "Primary port [8080]: " _PORT
+    PORT="${_PORT:-8080}"
+
+    read -rp "Container registry [ghcr.io/${OWNER:-{{OWNER}}}]: " _REGISTRY
+    REGISTRY="${_REGISTRY:-ghcr.io/${OWNER:-{{OWNER}}}}"
+
+    echo ""
+    echo "  Service: $SERVICE_NAME"
+    echo "  Port:    $PORT"
+    echo "  Registry: $REGISTRY"
+    echo ""
+    read -rp "Proceed? [Y/n] " CONFIRM
+    [[ "${CONFIRM:-Y}" =~ ^[Nn] ]] && echo "Aborted." && exit 0
+
+    echo ""
+    echo "Replacing container placeholders..."
+
+    # Brace tokens as variables (hex escapes avoid just interpolation)
+    LB=$(printf '\x7b\x7b')
+    RB=$(printf '\x7d\x7d')
+
+    SED_ARGS=(
+        -e "s|${LB}SERVICE_NAME${RB}|${SERVICE_NAME}|g"
+        -e "s|${LB}PORT${RB}|${PORT}|g"
+        -e "s|${LB}REGISTRY${RB}|${REGISTRY}|g"
+    )
+
+    find container/ -type f | while read -r file; do
+        if file --brief "$file" | grep -qi 'text\|ascii\|utf'; then
+            sed -i "${SED_ARGS[@]}" "$file"
+        fi
+    done
+
+    echo "Container templates initialised."
+    echo ""
+    echo "Next steps:"
+    echo "  1. Edit container/Containerfile — add your build commands"
+    echo "  2. Edit container/entrypoint.sh — set your application binary"
+    echo "  3. Review container/compose.toml — adjust services and volumes"
+    echo "  4. Build: just container-build"
+
+# Build container image via cerro-torre pipeline
+container-build *args:
+    #!/usr/bin/env bash
+    if [ -f "container/ct-build.sh" ]; then
+        cd container && ./ct-build.sh {{args}}
+    elif [ -f "container/Containerfile" ]; then
+        podman build -t {{project}}:latest -f container/Containerfile .
+    elif [ -f "build/Containerfile" ]; then
+        podman build -t {{project}}:latest -f build/Containerfile .
+    elif [ -f "Containerfile" ]; then
+        podman build -t {{project}}:latest -f Containerfile .
+    else
+        echo "No Containerfile found in container/, build/, or project root"
+        exit 1
+    fi
+
+# Verify compose configuration
+container-verify:
+    #!/usr/bin/env bash
+    if [ ! -f "container/compose.toml" ]; then
+        echo "No container/compose.toml found"
+        exit 1
+    fi
+    cd container
+    if command -v selur-compose &>/dev/null; then
+        selur-compose verify
+    else
+        echo "selur-compose not found, falling back to podman compose"
+        podman compose --file compose.toml config
+    fi
+
+# Start container stack
+container-up *args:
+    #!/usr/bin/env bash
+    if [ ! -f "container/compose.toml" ]; then
+        echo "No container/compose.toml found"
+        exit 1
+    fi
+    cd container
+    if command -v selur-compose &>/dev/null; then
+        selur-compose up {{args}}
+    else
+        podman compose --file compose.toml up {{args}}
+    fi
+
+# Stop container stack
+container-down:
+    #!/usr/bin/env bash
+    cd container 2>/dev/null || { echo "No container/ directory"; exit 1; }
+    if command -v selur-compose &>/dev/null; then
+        selur-compose down
+    else
+        podman compose --file compose.toml down
+    fi
+
+# Sign and verify container bundle (build + pack + sign + verify)
+container-sign:
+    #!/usr/bin/env bash
+    if [ -f "container/ct-build.sh" ]; then
+        cd container && ./ct-build.sh
+    else
+        echo "No container/ct-build.sh found"
+        exit 1
+    fi
+
+# Push signed bundle to registry
+container-push:
+    #!/usr/bin/env bash
+    if [ -f "container/ct-build.sh" ]; then
+        cd container && ./ct-build.sh --push
+    else
+        echo "No container/ct-build.sh found — falling back to podman push"
+        podman push {{project}}:latest
+    fi
+
+# Run container interactively (for debugging)
+container-run *args:
+    podman run --rm -it {{project}}:latest {{args}}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# CI & AUTOMATION
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Run full CI pipeline locally
+ci: deps quality
+    @echo "CI pipeline complete!"
+
+# Install git hooks
+install-hooks:
+    @mkdir -p .git/hooks
+    @cat > .git/hooks/pre-commit << 'HOOKEOF'
+    #!/bin/bash
+    just fmt-check || exit 1
+    just lint || exit 1
+    just assail || exit 1
+    HOOKEOF
+    @chmod +x .git/hooks/pre-commit
+    @echo "Git hooks installed"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# SECURITY
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Run security audit
+security: deps-audit
+    @echo "=== Security Audit ==="
+    @command -v trivy >/dev/null && trivy fs --severity HIGH,CRITICAL . || true
+    @echo "Security audit complete"
+
+# Generate SBOM
+sbom:
+    @mkdir -p docs/security
+    @command -v syft >/dev/null && syft . -o spdx-json > docs/security/sbom.spdx.json || echo "syft not found"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# VALIDATION & COMPLIANCE — see build/just/validate.just
+# ═══════════════════════════════════════════════════════════════════════════════
+
+import? "build/just/validate.just"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# STATE MANAGEMENT
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Update STATE.a2ml timestamp
+state-touch:
+    @if [ -f ".machine_readable/STATE.a2ml" ]; then \
+        sed -i 's/last-updated = "[^"]*"/last-updated = "'"$(date +%Y-%m-%d)"'"/' .machine_readable/STATE.a2ml && \
+        echo "STATE.a2ml timestamp updated"; \
+    fi
+
+# Show current phase from STATE.a2ml
+state-phase:
+    @grep -oP 'phase\s*=\s*"\K[^"]+' .machine_readable/STATE.a2ml 2>/dev/null | head -1 || echo "unknown"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# GUIX & NIX
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Enter Guix development shell (primary)
+guix-shell:
+    guix shell -D -f guix.scm
+
+# Build with Guix
+guix-build:
+    guix build -f guix.scm
+
+# Enter Nix development shell (fallback)
+nix-shell:
+    @if [ -f "flake.nix" ]; then nix develop; else echo "No flake.nix"; fi
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# HYBRID AUTOMATION
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Run local automation tasks
+automate task="all":
+    #!/usr/bin/env bash
+    case "{{task}}" in
+        all) just fmt && just lint && just test && just docs && just state-touch ;;
+        cleanup) just clean && find . -name "*.orig" -delete && find . -name "*~" -delete ;;
+        update) just deps && just validate ;;
+        *) echo "Unknown: {{task}}. Use: all, cleanup, update" && exit 1 ;;
+    esac
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# COMBINATORIC MATRIX RECIPES
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Build matrix: [debug|release] x [target] x [features]
+build-matrix mode="debug" target="" features="":
+    @echo "Build matrix: mode={{mode}} target={{target}} features={{features}}"
+
+# Test matrix: [unit|integration|e2e|all] x [verbosity] x [parallel]
+test-matrix suite="unit" verbosity="normal" parallel="true":
+    @echo "Test matrix: suite={{suite}} verbosity={{verbosity}} parallel={{parallel}}"
+
+# Container matrix: [build|run|push|shell|scan] x [registry] x [tag]
+container-matrix action="build" registry="ghcr.io/{{OWNER}}" tag="latest":
+    @echo "Container matrix: action={{action}} registry={{registry}} tag={{tag}}"
+
+# CI matrix: [lint|test|build|security|all] x [quick|full]
+ci-matrix stage="all" depth="quick":
+    @echo "CI matrix: stage={{stage}} depth={{depth}}"
+
+# Show all matrix combinations
+combinations:
+    @echo "=== Combinatoric Matrix Recipes ==="
+    @echo ""
+    @echo "Build Matrix: just build-matrix [debug|release] [target] [features]"
+    @echo "Test Matrix:  just test-matrix [unit|integration|e2e|all] [verbosity] [parallel]"
+    @echo "Container:    just container-matrix [build|run|push|shell|scan] [registry] [tag]"
+    @echo "CI Matrix:    just ci-matrix [lint|test|build|security|all] [quick|full]"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# VERSION CONTROL
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Show git status
+status:
+    @git status --short
+
+# Show recent commits
+log count="20":
+    @git log --oneline -{{count}}
+
+# Generate CHANGELOG.md with git-cliff
+changelog:
+    @command -v git-cliff >/dev/null || { echo "git-cliff not found — install: cargo install git-cliff"; exit 1; }
+    git cliff --config .machine_readable/configs/git-cliff/cliff.toml --output CHANGELOG.md
+    @echo "Generated CHANGELOG.md"
+
+# Preview changelog for unreleased commits (does not write)
+changelog-preview:
+    @command -v git-cliff >/dev/null || { echo "git-cliff not found — install: cargo install git-cliff"; exit 1; }
+    git cliff --config .machine_readable/configs/git-cliff/cliff.toml --unreleased --strip header
+
+# Tag a new release (usage: just release-tag 1.2.3)
+release-tag version:
+    #!/usr/bin/env bash
+    TAG="v{{version}}"
+    if git rev-parse "$TAG" >/dev/null 2>&1; then
+        echo "Tag $TAG already exists"
+        exit 1
+    fi
+    just changelog
+    git add CHANGELOG.md
+    git commit -m "chore(release): prepare $TAG"
+    git tag -a "$TAG" -m "Release $TAG"
+    echo "Created tag $TAG — push with: git push origin main --tags"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# UTILITIES
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Count lines of code
+loc:
+    @find . \( -name "*.rs" -o -name "*.ex" -o -name "*.exs" -o -name "*.res" -o -name "*.gleam" -o -name "*.zig" -o -name "*.idr" -o -name "*.hs" -o -name "*.ncl" -o -name "*.scm" -o -name "*.adb" -o -name "*.ads" \) -not -path './target/*' -not -path './_build/*' 2>/dev/null | xargs wc -l 2>/dev/null | tail -1 || echo "0"
+
+# Show TODO comments
+todos:
+    @grep -rn "TODO\|FIXME\|HACK\|XXX" --include="*.rs" --include="*.ex" --include="*.res" --include="*.gleam" --include="*.zig" --include="*.idr" --include="*.hs" . 2>/dev/null || echo "No TODOs"
+
+# Open in editor
+edit:
+    ${EDITOR:-code} .
+
+# Run high-rigor security assault using panic-attacker
+maint-assault:
+    @./.machine_readable/scripts/maintenance/maint-assault.sh
+
+# Run panic-attacker pre-commit scan (foundational floor-raise requirement)
+assail:
+    @command -v panic-attack >/dev/null 2>&1 && panic-attack assail . || echo "WARN: panic-attack not found — install from https://github.com/hyperpolymath/panic-attacker"
+
+
+# Self-diagnostic — checks dependencies, permissions, paths
+doctor:
+    @echo "Running diagnostics for rsr-template-repo..."
+    @echo "Checking required tools..."
+    @command -v just >/dev/null 2>&1 && echo "  [OK] just" || echo "  [FAIL] just not found"
+    @command -v git >/dev/null 2>&1 && echo "  [OK] git" || echo "  [FAIL] git not found"
+    @echo "Checking for hardcoded paths..."
+    @grep -rn '$HOME\|$ECLIPSE_DIR' --include='*.rs' --include='*.ex' --include='*.res' --include='*.gleam' --include='*.sh' . 2>/dev/null | head -5 || echo "  [OK] No hardcoded paths"
+    @echo "Diagnostics complete."
+
+# Guided tour of key features
+tour:
+    @echo "=== rsr-template-repo Tour ==="
+    @echo ""
+    @echo "1. Project structure:"
+    @ls -la
+    @echo ""
+    @echo "2. Available commands: just --list"
+    @echo ""
+    @echo "3. Read README.adoc for full overview"
+    @echo "4. Read EXPLAINME.adoc for architecture decisions"
+    @echo "5. Run 'just doctor' to check your setup"
+    @echo ""
+    @echo "Tour complete! Try 'just --list' to see all available commands."
+
+# Open feedback channel with diagnostic context
+help-me:
+    @echo "=== rsr-template-repo Help ==="
+    @echo "Platform: $(uname -s) $(uname -m)"
+    @echo "Shell: $SHELL"
+    @echo ""
+    @echo "To report an issue:"
+    @echo "  https://github.com/hyperpolymath/rsr-template-repo/issues/new"
+    @echo ""
+    @echo "Include the output of 'just doctor' in your report."
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# FORMAL VERIFICATION (PROOFS) — see build/just/proofs.just
+# ═══════════════════════════════════════════════════════════════════════════════
+
+import? "build/just/proofs.just"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# SESSION MANAGEMENT (THIN BINDINGS TO CENTRAL STANDARDS)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Show canonical session-management command model
+session-help:
+    @echo "Canonical command model:"
+    @echo "  intake repo <path>"
+    @echo "  checkpoint change <path>"
+    @echo "  verify maintenance <path>"
+    @echo "  verify substantial <path>"
+    @echo "  verify release <path>"
+    @echo "  close planned <path>"
+    @echo "  close urgent <path>"
+    @echo "  recover repo <path>"
+    @echo "  handover full <path>"
+    @echo "  handover split <path>"
+    @echo "  handover model <path>"
+    @echo "  handover human <path>"
+    @echo ""
+    @echo "Use Just aliases below (thin wrappers around ./session/dispatch.sh)."
+
+# Canonical aliases (friendly recipe names that map to canonical commands)
+intake-repo path=".":
+    @./session/dispatch.sh intake repo "{{path}}"
+
+checkpoint-change path=".":
+    @./session/dispatch.sh checkpoint change "{{path}}"
+
+verify-maintenance path=".":
+    @./session/dispatch.sh verify maintenance "{{path}}"
+
+verify-substantial path=".":
+    @./session/dispatch.sh verify substantial "{{path}}"
+
+verify-release path=".":
+    @./session/dispatch.sh verify release "{{path}}"
+
+close-planned path=".":
+    @./session/dispatch.sh close planned "{{path}}"
+
+close-urgent path=".":
+    @./session/dispatch.sh close urgent "{{path}}"
+
+recover-repo path=".":
+    @./session/dispatch.sh recover repo "{{path}}"
+
+handover-full path=".":
+    @./session/dispatch.sh handover full "{{path}}"
+
+handover-split path=".":
+    @./session/dispatch.sh handover split "{{path}}"
+
+handover-model path=".":
+    @./session/dispatch.sh handover model "{{path}}"
+
+handover-human path=".":
+    @./session/dispatch.sh handover human "{{path}}"
+
+secret-scan-trufflehog:
+    @command -v trufflehog >/dev/null && trufflehog filesystem . --only-verified || true

--- a/bag/lib/bag/ci_baton.ex
+++ b/bag/lib/bag/ci_baton.ex
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+defmodule Bag.CiBaton do
+  @moduledoc """
+  A CI-check Baton: a mobile unit of CI work.
+
+  Where `Bag.Baton` carries a counter that a Wasm module increments, a
+  `CiBaton` carries a real estate CI check (`command`) plus the capability a
+  node must have to run it (`required_cap`). Once executed on a capable node the
+  Zig host freezes the verdict; that frozen verdict is the portable artifact
+  that replaces a paid GitHub Actions run — it can migrate to, and be consumed
+  on, any other node without re-executing the check.
+  """
+  defstruct [:id, :check_id, :node, :required_cap, :command, :verdict, :exit_code]
+
+  @type verdict :: :pending | :pass | :fail | :suspended | :error
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          check_id: String.t(),
+          node: String.t(),
+          required_cap: String.t(),
+          command: [String.t()],
+          verdict: verdict(),
+          exit_code: integer() | nil
+        }
+
+  @doc """
+  Build a new CI-check Baton.
+
+  `check_id` names the check (e.g. "zig-fmt"); `command` is the argv list to run
+  (e.g. `["zig", "fmt", "--check", "build.zig"]`). Options: `:node` (default
+  "mesh-server-1") and `:required_cap` (default "linux").
+  """
+  def new(check_id, command, opts \\ []) when is_binary(check_id) and is_list(command) do
+    %__MODULE__{
+      id: "cib-" <> (:crypto.strong_rand_bytes(6) |> Base.encode16(case: :lower)),
+      check_id: check_id,
+      node: Keyword.get(opts, :node, "mesh-server-1"),
+      required_cap: Keyword.get(opts, :required_cap, "linux"),
+      command: command,
+      verdict: :pending,
+      exit_code: nil
+    }
+  end
+end

--- a/bag/lib/bag/ci_sweep.ex
+++ b/bag/lib/bag/ci_sweep.ex
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+defmodule Bag.CiSweep do
+  @moduledoc """
+  Runs a *set* of estate CI checks as Batons through the mesh — the local
+  emitter that `hypatia/scripts/ci-health` calls instead of spending GitHub
+  Actions minutes. Each check is a map:
+
+      %{check_id: "zig-fmt", command: ["zig", "fmt", "--check", "build.zig"], required_cap: "zig"}
+
+  `required_cap` defaults to "linux". Returns `{results, summary}` where
+  `results` is a list of per-check verdicts and `summary` counts verdicts.
+  """
+  alias Bag.Mesh
+
+  def run(checks) when is_list(checks) do
+    results =
+      Enum.map(checks, fn check ->
+        cap = Map.get(check, :required_cap, "linux")
+        {verdict, node, _baton} = Mesh.submit_check(check.check_id, check.command, required_cap: cap)
+        %{check_id: check.check_id, verdict: verdict, node: node}
+      end)
+
+    summary = Enum.frequencies_by(results, & &1.verdict)
+    {results, summary}
+  end
+
+  @doc """
+  True only if every check passed — the gate a caller (e.g. hypatia) checks to
+  decide a green/red verdict for the whole sweep, with zero paid minutes.
+  """
+  def all_passed?({results, _summary}), do: Enum.all?(results, &(&1.verdict == :pass))
+end

--- a/bag/lib/bag/executor.ex
+++ b/bag/lib/bag/executor.ex
@@ -9,6 +9,18 @@ defmodule Bag.Executor do
   @executor_path Path.expand("../../../zig-out/bin/bag_of_actions", __DIR__)
 
   @doc """
+  Returns the estate node names, read from the single mirrored manifest
+  (`estate.zig` ← `verification/proofs/Bag/Estate.idr`) via the Zig host — so the
+  orchestrator never keeps its own copy of the node list to drift out of step.
+  """
+  def list_nodes do
+    case System.cmd(@executor_path, ["nodes"], cd: Path.expand("../../../", __DIR__)) do
+      {output, 0} -> String.split(output, "\n", trim: true)
+      {_output, _code} -> []
+    end
+  end
+
+  @doc """
   Checks if a node satisfies the required capabilities using the Idris-to-Zig bridge.
   """
   def node_satisfies?(node_name, requirements) do
@@ -18,6 +30,53 @@ defmodule Bag.Executor do
       {_output, 0} -> true
       {_output, _code} -> false
     end
+  end
+
+  @doc """
+  Runs a CI-check Baton on its capability-matched node, via the Zig `check`
+  subcommand, and freezes the verdict to `freeze_path`.
+
+  Returns `{verdict, updated_baton, output}` where verdict is one of
+  `:pass | :fail | :suspended | :error`. No GitHub Actions minutes are used —
+  the check runs on this (owned) node and the verdict is the portable artifact.
+  """
+  def run_check(%Bag.CiBaton{} = b, freeze_path) do
+    args = ["check", b.node, b.required_cap, b.check_id, freeze_path | b.command]
+
+    {output, code} =
+      System.cmd(@executor_path, args, cd: Path.expand("../../../", __DIR__), stderr_to_stdout: true)
+
+    verdict =
+      case code do
+        0 -> :pass
+        1 -> :fail
+        2 -> :suspended
+        _ -> :error
+      end
+
+    {verdict, %{b | verdict: verdict, exit_code: code}, output}
+  end
+
+  @doc """
+  Thaws a frozen CI-check verdict on another node — zero re-execution.
+  Returns `{verdict, output}`.
+  """
+  def thaw_check(freeze_path) do
+    {output, code} =
+      System.cmd(@executor_path, ["thaw", freeze_path],
+        cd: Path.expand("../../../", __DIR__),
+        stderr_to_stdout: true
+      )
+
+    verdict =
+      case code do
+        0 -> :pass
+        1 -> :fail
+        3 -> :tampered
+        _ -> :error
+      end
+
+    {verdict, output}
   end
 
   @doc """

--- a/bag/lib/bag/mesh.ex
+++ b/bag/lib/bag/mesh.ex
@@ -5,12 +5,26 @@ defmodule Bag.Mesh do
   The distributed orchestrator for Batons.
   """
   use GenServer
-  alias Bag.{Baton, Executor}
+  alias Bag.{Baton, CiBaton, Executor}
 
   def start_link(opts) do
     {:ok, pid} = GenServer.start_link(__MODULE__, opts, name: __MODULE__)
     :ok = :pg.join(:bag_mesh, pid)
     {:ok, pid}
+  end
+
+  @doc """
+  Submit a CI-check Baton to the mesh. The orchestrator selects an estate node
+  that satisfies `required_cap` (reading the node list from the mirrored
+  manifest, capability-matching via the Idris-to-Zig bridge), runs the check
+  there, and freezes an attested verdict — with ZERO GitHub Actions minutes.
+
+  Options: `:required_cap` (default "linux"), `:freeze_path`.
+  Returns `{verdict, node, baton}` where verdict is
+  `:pass | :fail | :suspended | :tampered | :error` (`node` is nil if suspended).
+  """
+  def submit_check(check_id, command, opts \\ []) when is_binary(check_id) and is_list(command) do
+    GenServer.call(__MODULE__, {:submit_check, check_id, command, opts}, 60_000)
   end
 
   @doc """
@@ -67,6 +81,32 @@ defmodule Bag.Mesh do
     # Ensure :pg is started (it's often started by default but let's be safe)
     # Actually :pg.start_link() is for a scope. The default scope is always available.
     {:ok, %{batons: %{}}}
+  end
+
+  @impl true
+  def handle_call({:submit_check, check_id, command, opts}, _from, state) do
+    required_cap = Keyword.get(opts, :required_cap, "linux")
+
+    freeze_path =
+      Keyword.get(opts, :freeze_path, Path.join(System.tmp_dir!(), "#{check_id}.baton"))
+
+    # Select a capable node from the mirrored estate manifest.
+    capable =
+      Executor.list_nodes()
+      |> Enum.filter(fn node -> Executor.node_satisfies?(node, [required_cap]) end)
+
+    case capable do
+      [] ->
+        IO.puts("Mesh: NO node satisfies '#{required_cap}' for check #{check_id}. Suspended.")
+        {:reply, {:suspended, nil, nil}, state}
+
+      [node | _] ->
+        baton = CiBaton.new(check_id, command, node: node, required_cap: required_cap)
+        IO.puts("Mesh: routing check #{check_id} → #{node} (cap: #{required_cap})")
+        {verdict, updated, _output} = Executor.run_check(baton, freeze_path)
+        IO.puts("Mesh: check #{check_id} verdict=#{verdict} on #{node} (0 GitHub minutes)")
+        {:reply, {verdict, node, updated}, state}
+    end
   end
 
   @impl true

--- a/bag/lib/mix/tasks/bag.sweep.ex
+++ b/bag/lib/mix/tasks/bag.sweep.ex
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+defmodule Mix.Tasks.Bag.Sweep do
+  @shortdoc "Run a CI-check Baton sweep from a manifest (0 GitHub minutes)"
+  @moduledoc """
+  Run a set of estate CI checks as Batons on owned compute — zero GitHub
+  Actions minutes — and emit a ci-health-compatible report.
+
+      mix bag.sweep [manifest.exs]
+
+  The manifest (default `../ci-checks.exs`, i.e. the repo root) returns a list of
+  `%{check_id, command, required_cap}` maps. Each check is routed through
+  `Bag.Mesh` to a capability-matched node, run there, and its verdict frozen +
+  attested.
+
+  Output:
+    * stdout — one TSV line per check: `check_id<TAB>BATON-<VERDICT><TAB>node`
+      (the line hypatia/ci-health folds into its estate report).
+    * stderr — a human summary.
+    * exit status — 0 if every check passed, 1 otherwise (a CI gate).
+  """
+  use Mix.Task
+
+  @impl Mix.Task
+  def run(args) do
+    Mix.Task.run("app.start")
+
+    path = List.first(args) || "../ci-checks.exs"
+    {checks, _bindings} = Code.eval_file(path)
+    {results, summary} = Bag.CiSweep.run(checks)
+
+    # Machine-readable TSV on stdout (consumed by hypatia/ci-health).
+    Enum.each(results, fn r ->
+      verdict = r.verdict |> to_string() |> String.upcase()
+      IO.puts("#{r.check_id}\tBATON-#{verdict}\t#{r.node || "-"}")
+    end)
+
+    IO.puts(:stderr, "\nbag.sweep: #{inspect(summary)} (0 GitHub minutes)")
+
+    if Bag.CiSweep.all_passed?({results, summary}) do
+      IO.puts(:stderr, "bag.sweep: ALL PASS ✅")
+    else
+      IO.puts(:stderr, "bag.sweep: NOT GREEN ❌")
+      exit({:shutdown, 1})
+    end
+  end
+end

--- a/bag/test/ci_baton_test.exs
+++ b/bag/test/ci_baton_test.exs
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+defmodule Bag.CiBatonTest do
+  @moduledoc """
+  End-to-end smoke test for the CI-check Baton: runs a REAL estate CI check
+  (`zig fmt --check`) through the Zig host on a capability-matched node, with
+  ZERO GitHub Actions minutes, and proves the frozen verdict survives migration.
+  """
+  use ExUnit.Case, async: false
+  alias Bag.{CiBaton, Executor}
+
+  @repo_root Path.expand("../..", __DIR__)
+
+  setup_all do
+    # The check runs through the compiled Zig host — make sure it exists.
+    {_out, 0} = System.cmd("zig", ["build"], cd: @repo_root, stderr_to_stdout: true)
+    :ok
+  end
+
+  setup do
+    freeze = Path.join(System.tmp_dir!(), "cib-test-#{:rand.uniform(1_000_000)}.txt")
+    on_exit(fn -> File.rm(freeze) end)
+    {:ok, freeze: freeze}
+  end
+
+  test "a clean file PASSES the formatting check via a Baton (0 GitHub minutes)", %{freeze: freeze} do
+    baton = CiBaton.new("zig-fmt-clean", ["zig", "fmt", "--check", "build.zig"])
+
+    assert {:pass, updated, _output} = Executor.run_check(baton, freeze)
+    assert updated.verdict == :pass
+    assert updated.exit_code == 0
+    assert File.exists?(freeze)
+    assert File.read!(freeze) =~ "verdict=pass"
+  end
+
+  test "a badly-formatted file FAILS the check and freezes a fail verdict", %{freeze: freeze} do
+    baton = CiBaton.new("zig-fmt-dirty", ["zig", "fmt", "--check", "src/estate.zig"])
+
+    assert {:fail, updated, _output} = Executor.run_check(baton, freeze)
+    assert updated.verdict == :fail
+    assert updated.exit_code == 1
+    assert File.read!(freeze) =~ "verdict=fail"
+  end
+
+  test "a check is SUSPENDED (not failed) when no node has the capability", %{freeze: freeze} do
+    baton =
+      CiBaton.new("needs-guix", ["zig", "fmt", "--check", "build.zig"],
+        node: "mesh-github-runner",
+        required_cap: "guix"
+      )
+
+    assert {:suspended, updated, _output} = Executor.run_check(baton, freeze)
+    assert updated.verdict == :suspended
+  end
+
+  test "a frozen PASS verdict can be thawed on another node with no re-execution", %{freeze: freeze} do
+    baton = CiBaton.new("zig-fmt-migrate", ["zig", "fmt", "--check", "build.zig"])
+    assert {:pass, _updated, _output} = Executor.run_check(baton, freeze)
+
+    # Another node consumes the verdict from the frozen envelope alone.
+    assert {:pass, output} = Executor.thaw_check(freeze)
+    assert output =~ "VERDICT=pass"
+  end
+end

--- a/bag/test/ci_sweep_manifest_test.exs
+++ b/bag/test/ci_sweep_manifest_test.exs
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+defmodule Bag.CiSweepManifestTest do
+  @moduledoc """
+  Wires the dogfood manifest (`ci-checks.exs`): proves bag-of-actions can run
+  its OWN CI as Batons, all green, with zero GitHub Actions minutes.
+  """
+  use ExUnit.Case, async: false
+
+  @repo_root Path.expand("../..", __DIR__)
+
+  setup_all do
+    {_out, 0} = System.cmd("zig", ["build"], cd: @repo_root, stderr_to_stdout: true)
+    :ok
+  end
+
+  test "the dogfood manifest checks all pass as Batons" do
+    {checks, _bindings} = Code.eval_file(Path.join(@repo_root, "ci-checks.exs"))
+    assert is_list(checks) and checks != []
+
+    {results, summary} = Bag.CiSweep.run(checks)
+    assert Bag.CiSweep.all_passed?({results, summary}),
+           "manifest sweep not green: #{inspect(summary)} / #{inspect(results)}"
+  end
+end

--- a/bag/test/mesh_check_test.exs
+++ b/bag/test/mesh_check_test.exs
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+defmodule Bag.MeshCheckTest do
+  @moduledoc """
+  Integration test: CI-check Batons routed THROUGH the `Bag.Mesh` orchestrator
+  (not just the Executor) to a capability-matched node, plus the `Bag.CiSweep`
+  emitter — all on owned compute, zero GitHub Actions minutes.
+  """
+  use ExUnit.Case, async: false
+  alias Bag.{Mesh, CiSweep, Executor}
+
+  @repo_root Path.expand("../..", __DIR__)
+
+  setup_all do
+    {_out, 0} = System.cmd("zig", ["build"], cd: @repo_root, stderr_to_stdout: true)
+    :ok
+  end
+
+  test "node list is read from the mirrored manifest (no Elixir-side copy)" do
+    nodes = Executor.list_nodes()
+    assert "mesh-server-1" in nodes
+    assert "mesh-github-runner" in nodes
+  end
+
+  test "Mesh routes a check to a capability-matched node and returns a pass" do
+    assert {:pass, node, baton} =
+             Mesh.submit_check("mesh-pass", ["zig", "fmt", "--check", "build.zig"],
+               required_cap: "zig"
+             )
+
+    assert node in ["mesh-laptop", "mesh-server-1"]
+    assert baton.verdict == :pass
+  end
+
+  test "Mesh reports a real fail verdict through the orchestrator" do
+    assert {:fail, _node, baton} =
+             Mesh.submit_check("mesh-fail", ["zig", "fmt", "--check", "src/estate.zig"],
+               required_cap: "zig"
+             )
+
+    assert baton.verdict == :fail
+  end
+
+  test "Mesh SUSPENDS when no node can satisfy the (unknown/unprovable) capability" do
+    assert {:suspended, nil, nil} =
+             Mesh.submit_check("mesh-susp", ["true"], required_cap: "bogus-cap")
+  end
+
+  test "CiSweep runs a batch of checks and summarises verdicts" do
+    checks = [
+      %{check_id: "sweep-ok", command: ["zig", "fmt", "--check", "build.zig"], required_cap: "zig"},
+      %{check_id: "sweep-bad", command: ["zig", "fmt", "--check", "src/estate.zig"], required_cap: "zig"}
+    ]
+
+    {results, summary} = CiSweep.run(checks)
+
+    assert length(results) == 2
+    assert summary[:pass] == 1
+    assert summary[:fail] == 1
+    refute CiSweep.all_passed?({results, summary})
+  end
+end

--- a/ci-checks.exs
+++ b/ci-checks.exs
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+#
+# Dogfood CI manifest: bag-of-actions' OWN checks, run as Batons on owned
+# compute (zero GitHub Actions minutes). Consumed by `mix bag.sweep` and, in
+# turn, by hypatia/ci-health. Each entry: check_id, command (argv), required_cap.
+[
+  %{
+    check_id: "zig-fmt",
+    command: ["zig", "fmt", "--check", "build.zig", "src/root.zig"],
+    required_cap: "zig"
+  },
+  %{
+    check_id: "zig-build-test",
+    command: ["zig", "build", "test"],
+    required_cap: "zig"
+  }
+]

--- a/docs/ci-check-baton.adoc
+++ b/docs/ci-check-baton.adoc
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+= CI-check Baton — estate CI on owned compute
+:toc: preamble
+:icons: font
+
+The *CI-check Baton* is the first concrete answer to the GitHub Actions billing
+wall (see `dev-notes/2026-06-13-ci-billing-to-bag-of-actions-pivot.adoc`): an
+estate CI check that runs on *owned compute* with *zero billable minutes*, is
+routed only to a node that has the *required capability*, and whose *verdict is
+frozen and attested* into a portable envelope that can migrate to — and be
+consumed on — another node without re-running the check.
+
+It sits alongside the original counter demo (`Bag.Baton` + `counter.wat`): that
+demo proves a Baton can carry mobile *state*; the CI-check Baton proves a Baton
+can carry mobile *CI work and its (tamper-evident) verdict*.
+
+== The model
+
+[cols="1,3"]
+|===
+| `check_id`     | names the check, e.g. `zig-fmt`
+| `command`      | the argv to run, e.g. `zig fmt --check build.zig`
+| `required_cap` | the capability a node must have to run it (`linux`, `guix`, `zig`, `rust`, `cargo`, `deno`, …)
+| `node`         | the node the work is routed to
+| `verdict`      | `pending` (frozen, not yet run) / `pass` / `fail`
+| `exit_code`    | the executed check's exit status
+| `digest`       | HMAC-SHA256 over the fields (keyed by `BAG_ATTEST_KEY`) — makes the verdict tamper-evident
+|===
+
+Lifecycle:
+
+. *Match* — the orchestrator picks an estate node that satisfies `required_cap`.
+  Capability-matching is `estate.nodeSatisfies` (Zig), mirrored from the formal
+  source of truth `verification/proofs/Bag/Estate.idr` /
+  `verification/proofs/Bag/Protocol.idr`. An *unknown/unprovable* capability
+  never matches (fail-safe).
+. *Execute* — if a capable node exists, the check runs there. If not, the work
+  is *suspended* (a `pending` Baton is frozen so it can migrate to a capable node).
+. *Freeze + attest* — the verdict is written to a versioned envelope
+  (`BAG-CHECK-BATON v1`) with an HMAC digest.
+. *Thaw* — any other node reads the verdict from the envelope and *verifies the
+  digest*; a tampered envelope is rejected (exit 3). Zero re-execution.
+
+The capability taxonomy is kept in step across THREE layers — add a capability
+in `Protocol.idr` (`capToTag`) AND `estate.Capability` (Zig) AND the Elixir
+translation, or in none. The Elixir orchestrator reads the node list from the
+single mirrored manifest via `bag_of_actions nodes` (no 4th copy to drift).
+
+== Run it
+
+[source,sh]
+----
+# One-shot demonstration (build + pass + fail + suspend + attest/tamper + thaw):
+./scripts/ci-baton-demo.sh
+
+# Directly via the Zig host:
+zig build
+./zig-out/bin/bag_of_actions nodes                  # node names from the manifest
+./zig-out/bin/bag_of_actions check mesh-server-1 zig my-check /tmp/v.txt zig fmt --check build.zig
+./zig-out/bin/bag_of_actions thaw /tmp/v.txt         # verifies attestation, then reports
+
+# Through the Elixir mesh (routes to a capability-matched node):
+cd bag && mix test                                   # 10 e2e tests
+----
+
+[source,elixir]
+----
+# A single check, routed through the orchestrator:
+{:pass, node, _baton} = Bag.Mesh.submit_check("zig-fmt", ["zig","fmt","--check","build.zig"], required_cap: "zig")
+
+# A whole sweep (the entry point hypatia/ci-health will call):
+checks = [%{check_id: "fmt", command: ["zig","fmt","--check","build.zig"], required_cap: "zig"}]
+{results, summary} = Bag.CiSweep.run(checks)
+Bag.CiSweep.all_passed?({results, summary})          # green/red for the sweep, 0 paid minutes
+----
+
+Exit codes from the `check`/`thaw` subcommands double as a CI gate: `0` = pass,
+`1` = fail, `2` = suspended (no capable node), `3` = tampered (attestation failed).
+
+== Why this dissolves the billing wall
+
+A GitHub-hosted run costs billable minutes and, on this estate, is gated behind
+an unpaid spending limit (wall A) and a restrictive action allow-list (wall B).
+A CI-check Baton runs the *same check* on a node we already own and pay nothing
+extra for, and the *attested verdict* — not the runner — becomes the artifact
+other nodes trust. The check that GitHub would have refused to start runs anyway.
+
+== Done / next
+
+Done (wired across Idris ↔ Zig ↔ Elixir):
+
+* Toolchain capability taxonomy (`Zig`/`Rust`/`Cargo`/`Deno`), mirrored in all
+  three layers; dev nodes carry the toolchain caps.
+* Attestation: HMAC-SHA256 digest, verified on thaw, tamper rejected.
+* `CiBaton` wired into `Bag.Mesh` (`submit_check`) + the `Bag.CiSweep` batch emitter.
+* Fail-safe matching (unknown capability never matches).
+* Formal layer now compiles (`idris2 --build bag.ipkg` — three pre-existing
+  breaks fixed: `List.find`, `with`-clause shorthand, non-linear patterns).
+
+Next:
+
+* *Cross-repo (push-gated):* bridge `hypatia/scripts/ci-health` to call
+  `Bag.CiSweep.run/1` for the estate's real checks instead of flagging GitHub
+  failures.
+* Replace the HMAC dev key with real per-node signing (ed25519 / the estate
+  signing key) so a thawed verdict is authenticity-evident, not just integrity-evident.
+* WASI-compile self-contained checks so the check body itself is a frozen Wasm
+  Baton (the purest form of the model).

--- a/scripts/ci-baton-demo.sh
+++ b/scripts/ci-baton-demo.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+#
+# ci-baton-demo.sh — Run an estate CI check as a Baton on owned compute.
+#
+# This is the bag-of-actions answer to the GitHub Actions billing wall:
+# a CI check runs LOCALLY (zero billable minutes), routed only to a node that
+# has the required capability, and its verdict is FROZEN into a portable
+# envelope that can migrate to / be consumed on another node without re-running.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+BIN=./zig-out/bin/bag_of_actions
+FREEZE_DIR="${TMPDIR:-/tmp}"
+
+echo "=== Building the Zig host ==="
+zig build
+echo
+
+echo "=== Estate nodes (read from the single mirrored manifest) ==="
+$BIN nodes
+echo
+
+echo "=== (1) PASS: a clean file checked on a zig-capable node ==="
+$BIN check mesh-server-1 zig zig-fmt-clean "$FREEZE_DIR/cib-pass.txt" zig fmt --check build.zig \
+  && echo "gate: PASS (exit 0)" || echo "gate: FAIL (exit $?)"
+echo
+
+echo "=== (2) FAIL: a badly-formatted file (real, honest fail) ==="
+$BIN check mesh-server-1 zig zig-fmt-dirty "$FREEZE_DIR/cib-fail.txt" zig fmt --check src/estate.zig \
+  && echo "gate: PASS (exit 0)" || echo "gate: FAIL (exit $?)"
+echo
+
+echo "=== (3) SUSPENDED: required capability absent → work suspended, no minutes burned ==="
+$BIN check mesh-github-runner zig needs-zig "$FREEZE_DIR/cib-susp.txt" zig fmt --check build.zig \
+  && echo "gate: PASS (exit 0)" || echo "gate: SUSPENDED/FAIL (exit $?)"
+echo
+
+echo "=== (4) THAW: another node consumes the frozen PASS verdict (attestation verified) ==="
+$BIN thaw "$FREEZE_DIR/cib-pass.txt" \
+  && echo "gate: PASS (exit 0)" || echo "gate: FAIL (exit $?)"
+echo
+
+echo "=== (5) TAMPER: forge verdict=pass→fail in the frozen file, then thaw → REJECTED ==="
+sed 's/verdict=pass/verdict=fail/' "$FREEZE_DIR/cib-pass.txt" > "$FREEZE_DIR/cib-forged.txt"
+$BIN thaw "$FREEZE_DIR/cib-forged.txt" \
+  && echo "gate: PASS (exit 0)" || echo "gate: REJECTED (exit $?)"
+echo
+
+echo "=== Frozen PASS envelope (the attested, portable artifact that replaces a paid run) ==="
+cat "$FREEZE_DIR/cib-pass.txt"

--- a/src/estate.zig
+++ b/src/estate.zig
@@ -2,7 +2,8 @@
 // Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 const std = @import("std");
 
-/// Mapping to Idris 2 Bag.Protocol.Capability tags
+/// Mapping to Idris 2 Bag.Protocol.Capability tags (capToTag). Kept in step with
+/// verification/proofs/Bag/Protocol.idr — add a capability in BOTH or neither.
 pub const Capability = enum(u32) {
     linux = 1,
     macos = 2,
@@ -10,6 +11,10 @@ pub const Capability = enum(u32) {
     guix = 4,
     trusted_host = 5,
     secret_access = 6,
+    zig = 7,
+    rust = 8,
+    cargo = 9,
+    deno = 10,
 
     pub fn fromString(s: []const u8) ?Capability {
         if (std.mem.eql(u8, s, "linux")) return .linux;
@@ -18,6 +23,10 @@ pub const Capability = enum(u32) {
         if (std.mem.eql(u8, s, "guix")) return .guix;
         if (std.mem.eql(u8, s, "trusted_host")) return .trusted_host;
         if (std.mem.eql(u8, s, "secret_access")) return .secret_access;
+        if (std.mem.eql(u8, s, "zig")) return .zig;
+        if (std.mem.eql(u8, s, "rust")) return .rust;
+        if (std.mem.eql(u8, s, "cargo")) return .cargo;
+        if (std.mem.eql(u8, s, "deno")) return .deno;
         return null;
     }
 };
@@ -31,17 +40,26 @@ pub const Node = struct {
 pub const estate = [_]Node{
     .{
         .name = "mesh-laptop",
-        .capabilities = &[_]Capability{ .macos, .guix, .trusted_host },
+        .capabilities = &[_]Capability{ .macos, .guix, .trusted_host, .zig },
     },
     .{
         .name = "mesh-server-1",
-        .capabilities = &[_]Capability{ .linux, .gpu, .guix, .trusted_host },
+        .capabilities = &[_]Capability{ .linux, .gpu, .guix, .trusted_host, .zig, .rust, .cargo, .deno },
     },
     .{
         .name = "mesh-github-runner",
         .capabilities = &[_]Capability{ .linux, .secret_access },
     },
 };
+
+/// Print the estate node names, one per line. Lets the Elixir orchestrator read
+/// the node list from this single mirrored manifest instead of duplicating it.
+pub fn listNodeNames(writer: anytype) !void {
+    for (estate) |node| {
+        try writer.writeAll(node.name);
+        try writer.writeAll("\n");
+    }
+}
 
 pub fn findNode(name: []const u8) ?Node {
     for (estate) |node| {

--- a/src/main.zig
+++ b/src/main.zig
@@ -40,6 +40,152 @@ pub const Baton = struct {
     }
 };
 
+/// The verdict a CI-check Baton carries once it has been executed on a node.
+/// `pending` = frozen before execution; `pass`/`fail` = the executed result.
+pub const Verdict = enum {
+    pending,
+    pass,
+    fail,
+
+    pub fn fromString(s: []const u8) ?Verdict {
+        if (std.mem.eql(u8, s, "pending")) return .pending;
+        if (std.mem.eql(u8, s, "pass")) return .pass;
+        if (std.mem.eql(u8, s, "fail")) return .fail;
+        return null;
+    }
+};
+
+/// A CI-check Baton: a mobile unit of CI work that names a check, declares the
+/// capability a node must have to run it, and — once executed — freezes the
+/// verdict so it can migrate to (and be consumed on) another node WITHOUT
+/// re-running the check. This is the bag-of-actions answer to paid CI minutes:
+/// the check runs on owned compute, and the verdict is the portable artifact.
+pub const CheckBaton = struct {
+    id: []const u8,
+    check_id: []const u8,
+    node: []const u8,
+    required_cap: estate.Capability,
+    verdict: Verdict,
+    exit_code: i32,
+    command: []const u8,
+    digest: [64]u8 = [_]u8{'0'} ** 64,
+
+    /// HMAC-SHA256 over the verdict-bearing fields, hex-encoded. Makes a frozen
+    /// verdict tamper-evident: another node recomputes this with the shared key
+    /// and rejects the Baton if it does not match. (Integrity/authenticity hook;
+    /// the key comes from BAG_ATTEST_KEY — see `attestKey`.)
+    pub fn digestHex(self: CheckBaton, allocator: std.mem.Allocator, key: []const u8) ![64]u8 {
+        const canon = try std.fmt.allocPrint(
+            allocator,
+            "{s}|{s}|{s}|{s}|{s}|{d}|{s}",
+            .{ self.id, self.check_id, self.node, @tagName(self.required_cap), @tagName(self.verdict), self.exit_code, self.command },
+        );
+        defer allocator.free(canon);
+
+        const HmacSha256 = std.crypto.auth.hmac.sha2.HmacSha256;
+        var mac: [HmacSha256.mac_length]u8 = undefined;
+        HmacSha256.create(&mac, canon, key);
+
+        const hexchars = "0123456789abcdef";
+        var hex: [64]u8 = undefined;
+        for (mac, 0..) |byte, i| {
+            hex[i * 2] = hexchars[byte >> 4];
+            hex[i * 2 + 1] = hexchars[byte & 0x0f];
+        }
+        return hex;
+    }
+
+    /// Recompute the digest and compare it to the one carried in the envelope.
+    pub fn verify(self: CheckBaton, allocator: std.mem.Allocator, key: []const u8) !bool {
+        const expected = try self.digestHex(allocator, key);
+        return std.mem.eql(u8, expected[0..], self.digest[0..]);
+    }
+
+    /// Freeze the Baton (incl. its verdict + attestation digest) to a versioned
+    /// text envelope.
+    pub fn freeze(self: CheckBaton, allocator: std.mem.Allocator, path: []const u8, key: []const u8) !void {
+        const dh = try self.digestHex(allocator, key);
+        const file = try std.fs.cwd().createFile(path, .{});
+        defer file.close();
+        const msg = try std.fmt.allocPrint(
+            allocator,
+            "BAG-CHECK-BATON v1\nid={s}\ncheck_id={s}\nnode={s}\nrequired_cap={s}\nverdict={s}\nexit_code={d}\ncommand={s}\ndigest=hmac-sha256:{s}\n",
+            .{ self.id, self.check_id, self.node, @tagName(self.required_cap), @tagName(self.verdict), self.exit_code, self.command, dh[0..] },
+        );
+        defer allocator.free(msg);
+        try file.writeAll(msg);
+    }
+
+    /// Thaw a frozen Baton. All string fields are heap-owned — call `deinit`.
+    pub fn thaw(allocator: std.mem.Allocator, path: []const u8) !CheckBaton {
+        const file = try std.fs.cwd().openFile(path, .{});
+        defer file.close();
+        const content = try file.readToEndAlloc(allocator, 8192);
+        defer allocator.free(content);
+
+        var b = CheckBaton{
+            .id = try allocator.dupe(u8, ""),
+            .check_id = try allocator.dupe(u8, ""),
+            .node = try allocator.dupe(u8, ""),
+            .required_cap = .linux,
+            .verdict = .pending,
+            .exit_code = 0,
+            .command = try allocator.dupe(u8, ""),
+        };
+
+        var lines = std.mem.splitScalar(u8, content, '\n');
+        while (lines.next()) |line| {
+            const eq = std.mem.indexOfScalar(u8, line, '=') orelse continue;
+            const key = line[0..eq];
+            const val = line[eq + 1 ..];
+            if (std.mem.eql(u8, key, "id")) {
+                allocator.free(b.id);
+                b.id = try allocator.dupe(u8, val);
+            } else if (std.mem.eql(u8, key, "check_id")) {
+                allocator.free(b.check_id);
+                b.check_id = try allocator.dupe(u8, val);
+            } else if (std.mem.eql(u8, key, "node")) {
+                allocator.free(b.node);
+                b.node = try allocator.dupe(u8, val);
+            } else if (std.mem.eql(u8, key, "required_cap")) {
+                b.required_cap = estate.Capability.fromString(val) orelse .linux;
+            } else if (std.mem.eql(u8, key, "verdict")) {
+                b.verdict = Verdict.fromString(val) orelse .pending;
+            } else if (std.mem.eql(u8, key, "exit_code")) {
+                b.exit_code = std.fmt.parseInt(i32, val, 10) catch 0;
+            } else if (std.mem.eql(u8, key, "command")) {
+                allocator.free(b.command);
+                b.command = try allocator.dupe(u8, val);
+            } else if (std.mem.eql(u8, key, "digest")) {
+                const hex = if (std.mem.startsWith(u8, val, "hmac-sha256:")) val["hmac-sha256:".len..] else val;
+                const n = @min(hex.len, 64);
+                @memcpy(b.digest[0..n], hex[0..n]);
+            }
+        }
+        return b;
+    }
+
+    pub fn deinit(self: CheckBaton, allocator: std.mem.Allocator) void {
+        allocator.free(self.id);
+        allocator.free(self.check_id);
+        allocator.free(self.node);
+        allocator.free(self.command);
+    }
+};
+
+/// The shared key used to attest frozen verdicts. Reads BAG_ATTEST_KEY; falls
+/// back to a documented dev placeholder (integrity-only until a real key is set).
+fn attestKey(allocator: std.mem.Allocator) ![]const u8 {
+    return std.process.getEnvVarOwned(allocator, "BAG_ATTEST_KEY") catch
+        try allocator.dupe(u8, "bag-of-actions-dev-key");
+}
+
+fn printOut(allocator: std.mem.Allocator, comptime fmt: []const u8, args: anytype) !void {
+    const s = try std.fmt.allocPrint(allocator, fmt, args);
+    defer allocator.free(s);
+    try std.fs.File.stdout().writeAll(s);
+}
+
 fn runGuixBuild(allocator: std.mem.Allocator, package: []const u8) ![]const u8 {
     std.debug.print("Guix Policy: Orchestrating build for {s}\n", .{package});
     const result = try std.process.Child.run(.{
@@ -68,7 +214,13 @@ pub fn main() !void {
     defer std.process.argsFree(allocator, args);
 
     if (args.len < 2) {
-        std.debug.print("Usage: {s} [init|run|match]\n", .{args[0]});
+        std.debug.print("Usage: {s} [init|run|match|nodes|check|thaw]\n", .{args[0]});
+        return;
+    }
+
+    if (std.mem.eql(u8, args[1], "nodes")) {
+        // Print the estate node names from the single mirrored manifest.
+        try estate.listNodeNames(std.fs.File.stdout());
         return;
     }
 
@@ -87,27 +239,103 @@ pub fn main() !void {
         defer allocator.free(reqs);
 
         var valid_count: usize = 0;
+        var has_unknown = false;
         for (args[3..]) |cap_str| {
             if (estate.Capability.fromString(cap_str)) |cap| {
                 reqs[valid_count] = cap;
                 valid_count += 1;
+            } else {
+                // An unknown/unprovable requirement can NEVER be satisfied.
+                has_unknown = true;
             }
         }
 
-        if (estate.nodeSatisfies(node_name, reqs[0..valid_count])) {
+        if (!has_unknown and estate.nodeSatisfies(node_name, reqs[0..valid_count])) {
             std.debug.print("MATCH: TRUE\n", .{});
             std.process.exit(0);
         } else {
             std.debug.print("MATCH: FALSE\n", .{});
             std.process.exit(1);
         }
+    } else if (std.mem.eql(u8, args[1], "check")) {
+        // bag_of_actions check <node> <cap> <check_id> <freeze_path> <cmd> [args...]
+        // Run an estate CI check as a Baton on a capability-matched node, then
+        // freeze the verdict. Exit 0 = pass, 1 = fail, 2 = no capable node.
+        if (args.len < 7) {
+            std.debug.print("Usage: {s} check <node> <cap> <check_id> <freeze_path> <cmd> [args...]\n", .{args[0]});
+            std.process.exit(64);
+        }
+        const node = args[2];
+        const cap = estate.Capability.fromString(args[3]) orelse {
+            std.debug.print("Unknown capability: {s}\n", .{args[3]});
+            std.process.exit(64);
+        };
+        const check_id = args[4];
+        const freeze_path = args[5];
+        const cmd_argv = args[6..];
+
+        const key = try attestKey(allocator);
+        defer allocator.free(key);
+
+        // 1. Capability gate: only run on a node that satisfies the requirement.
+        if (!estate.nodeSatisfies(node, &[_]estate.Capability{cap})) {
+            try printOut(allocator, "VERDICT=suspended\nReason: node '{s}' lacks capability '{s}'. Work suspended (no minutes burned).\n", .{ node, @tagName(cap) });
+            // Freeze a pending Baton so the work can migrate to a capable node.
+            const joined = try std.mem.join(allocator, " ", cmd_argv);
+            defer allocator.free(joined);
+            const baton = CheckBaton{ .id = check_id, .check_id = check_id, .node = node, .required_cap = cap, .verdict = .pending, .exit_code = -1, .command = joined };
+            try baton.freeze(allocator, freeze_path, key);
+            std.process.exit(2);
+        }
+
+        // 2. Execute the real check on this (capable) node.
+        const result = try std.process.Child.run(.{
+            .allocator = allocator,
+            .argv = cmd_argv,
+        });
+        defer allocator.free(result.stdout);
+        defer allocator.free(result.stderr);
+
+        const code: i32 = switch (result.term) {
+            .Exited => |c| @intCast(c),
+            else => 1,
+        };
+        const verdict: Verdict = if (code == 0) .pass else .fail;
+
+        // 3. Freeze the verdict — the portable artifact that replaces a paid run.
+        const joined = try std.mem.join(allocator, " ", cmd_argv);
+        defer allocator.free(joined);
+        const baton = CheckBaton{ .id = check_id, .check_id = check_id, .node = node, .required_cap = cap, .verdict = verdict, .exit_code = code, .command = joined };
+        try baton.freeze(allocator, freeze_path, key);
+
+        try printOut(allocator, "VERDICT={s}\ncheck_id={s} node={s} cap={s} exit_code={d}\nFrozen+attested to {s} (0 GitHub minutes)\n", .{ @tagName(verdict), check_id, node, @tagName(cap), code, freeze_path });
+        std.process.exit(if (verdict == .pass) 0 else 1);
+    } else if (std.mem.eql(u8, args[1], "thaw")) {
+        // bag_of_actions thaw <freeze_path>
+        // Consume a frozen verdict on another node — zero re-execution.
+        if (args.len < 3) {
+            std.debug.print("Usage: {s} thaw <freeze_path>\n", .{args[0]});
+            std.process.exit(64);
+        }
+        var baton = try CheckBaton.thaw(allocator, args[2]);
+        defer baton.deinit(allocator);
+
+        const key = try attestKey(allocator);
+        defer allocator.free(key);
+        if (!try baton.verify(allocator, key)) {
+            try printOut(allocator, "VERDICT=tampered\ncheck_id={s}: attestation digest does not match — verdict REJECTED.\n", .{baton.check_id});
+            std.process.exit(3);
+        }
+
+        try printOut(allocator, "VERDICT={s}\ncheck_id={s} node={s} cap={s} exit_code={d}\ncommand={s}\nattestation=verified\n", .{ @tagName(baton.verdict), baton.check_id, baton.node, @tagName(baton.required_cap), baton.exit_code, baton.command });
+        std.process.exit(if (baton.verdict == .pass) 0 else 1);
     } else if (std.mem.eql(u8, args[1], "run")) {
         var baton = try Baton.load(allocator, "baton.txt");
         defer allocator.free(baton.module_cid);
         defer if (baton.guix_package) |pkg| allocator.free(pkg);
         defer if (baton.required_cap) |cap| allocator.free(cap);
-        
-        std.debug.print("Resuming Baton [Counter: {d}, Module: {s}]\n", .{baton.counter, baton.module_cid});
+
+        std.debug.print("Resuming Baton [Counter: {d}, Module: {s}]\n", .{ baton.counter, baton.module_cid });
 
         // Step 1: Pre-execution Guix Action (Real World FFI simulation)
         if (baton.counter == 0) {
@@ -136,10 +364,126 @@ pub fn main() !void {
 
         const output = std.mem.trim(u8, result.stdout, " \n\r");
         const next_counter = try std.fmt.parseInt(i32, output, 10);
-        std.debug.print("Wasm State Update: {d} -> {d}\n", .{baton.counter, next_counter});
+        std.debug.print("Wasm State Update: {d} -> {d}\n", .{ baton.counter, next_counter });
 
         baton.counter = next_counter;
         try baton.save(allocator, "baton.txt");
         std.debug.print("Baton cycle complete. Saved for next node.\n", .{});
     }
+}
+
+test "CheckBaton freeze/thaw round-trips the verdict and verifies attestation" {
+    const a = std.testing.allocator;
+    const key = "test-key";
+    const original = CheckBaton{
+        .id = "cib-001",
+        .check_id = "zig-fmt-check",
+        .node = "mesh-server-1",
+        .required_cap = .zig,
+        .verdict = .pass,
+        .exit_code = 0,
+        .command = "zig fmt --check build.zig",
+    };
+    const path = "test-ci-baton-roundtrip.txt";
+    try original.freeze(a, path, key);
+    defer std.fs.cwd().deleteFile(path) catch {};
+
+    var thawed = try CheckBaton.thaw(a, path);
+    defer thawed.deinit(a);
+
+    try std.testing.expectEqualStrings(original.id, thawed.id);
+    try std.testing.expectEqualStrings(original.check_id, thawed.check_id);
+    try std.testing.expectEqualStrings(original.node, thawed.node);
+    try std.testing.expectEqualStrings(original.command, thawed.command);
+    try std.testing.expect(original.required_cap == thawed.required_cap);
+    try std.testing.expect(original.verdict == thawed.verdict);
+    try std.testing.expect(original.exit_code == thawed.exit_code);
+    try std.testing.expect(try thawed.verify(a, key));
+}
+
+test "CheckBaton preserves a fail verdict and nonzero exit code" {
+    const a = std.testing.allocator;
+    const original = CheckBaton{
+        .id = "cib-002",
+        .check_id = "zig-fmt-check",
+        .node = "mesh-server-1",
+        .required_cap = .zig,
+        .verdict = .fail,
+        .exit_code = 1,
+        .command = "zig fmt --check src/main.zig",
+    };
+    const path = "test-ci-baton-fail.txt";
+    try original.freeze(a, path, "test-key");
+    defer std.fs.cwd().deleteFile(path) catch {};
+
+    var thawed = try CheckBaton.thaw(a, path);
+    defer thawed.deinit(a);
+
+    try std.testing.expect(thawed.verdict == .fail);
+    try std.testing.expect(thawed.exit_code == 1);
+}
+
+test "attestation detects a tampered verdict" {
+    const a = std.testing.allocator;
+    const key = "test-key";
+    const original = CheckBaton{
+        .id = "cib-003",
+        .check_id = "zig-fmt-check",
+        .node = "mesh-server-1",
+        .required_cap = .zig,
+        .verdict = .fail,
+        .exit_code = 1,
+        .command = "zig fmt --check src/main.zig",
+    };
+    const path = "test-ci-baton-tamper.txt";
+    try original.freeze(a, path, key);
+    defer std.fs.cwd().deleteFile(path) catch {};
+
+    // Forge a pass verdict in the frozen envelope without re-attesting.
+    const content = blk: {
+        const rf = try std.fs.cwd().openFile(path, .{});
+        defer rf.close();
+        break :blk try rf.readToEndAlloc(a, 8192);
+    };
+    defer a.free(content);
+    const forged = try std.mem.replaceOwned(u8, a, content, "verdict=fail", "verdict=pass");
+    defer a.free(forged);
+    {
+        const f = try std.fs.cwd().createFile(path, .{});
+        defer f.close();
+        try f.writeAll(forged);
+    }
+
+    var thawed = try CheckBaton.thaw(a, path);
+    defer thawed.deinit(a);
+    try std.testing.expect(thawed.verdict == .pass); // the forged value parsed...
+    try std.testing.expect(!try thawed.verify(a, key)); // ...but attestation rejects it.
+}
+
+test "attestation with the wrong key fails verification" {
+    const a = std.testing.allocator;
+    const original = CheckBaton{
+        .id = "cib-004",
+        .check_id = "zig-fmt-check",
+        .node = "mesh-server-1",
+        .required_cap = .zig,
+        .verdict = .pass,
+        .exit_code = 0,
+        .command = "zig fmt --check build.zig",
+    };
+    const path = "test-ci-baton-wrongkey.txt";
+    try original.freeze(a, path, "key-a");
+    defer std.fs.cwd().deleteFile(path) catch {};
+
+    var thawed = try CheckBaton.thaw(a, path);
+    defer thawed.deinit(a);
+    try std.testing.expect(try thawed.verify(a, "key-a"));
+    try std.testing.expect(!try thawed.verify(a, "key-b"));
+}
+
+test "Verdict.fromString parses known tags and rejects unknown" {
+    try std.testing.expect(Verdict.fromString("pass").? == .pass);
+    try std.testing.expect(Verdict.fromString("fail").? == .fail);
+    try std.testing.expect(Verdict.fromString("pending").? == .pending);
+    try std.testing.expect(Verdict.fromString("bogus") == null);
 }

--- a/verification/proofs/Bag/Estate.idr
+++ b/verification/proofs/Bag/Estate.idr
@@ -4,6 +4,7 @@
 module Bag.Estate
 
 import Bag.Protocol
+import Data.List
 
 %default total
 
@@ -19,15 +20,15 @@ record Node where
 public export
 estate : List Node
 estate =
-  [ MkNode "mesh-laptop"        [MacOS, Guix, TrustedHost "Jonathan"]
-  , MkNode "mesh-server-1"      [Linux, GPU, Guix, TrustedHost "Core-Infrastructure"]
+  [ MkNode "mesh-laptop"        [MacOS, Guix, TrustedHost "Jonathan", Zig]
+  , MkNode "mesh-server-1"      [Linux, GPU, Guix, TrustedHost "Core-Infrastructure", Zig, Rust, Cargo, Deno]
   , MkNode "mesh-github-runner" [Linux, SecretAccess "GitHub-Deploy-Token"]
   ]
 
 ||| Lookup a node by name in the estate.
 public export
 findNode : String -> Maybe Node
-findNode target = List.find (\n => name n == target) estate
+findNode target = find (\n => name n == target) estate
 
 ||| Verify that a specific node in the estate satisfies a set of requirements.
 public export

--- a/verification/proofs/Bag/Handoff.idr
+++ b/verification/proofs/Bag/Handoff.idr
@@ -31,8 +31,8 @@ data HandoffResult : HandoffRequest -> Type where
 export
 validateHandoff : (req : HandoffRequest) -> HandoffResult req
 validateHandoff req with (satisfies (requiredCap (baton req)) (targetCaps req)) proof p
-  | True  = Validated req p
-  | False = Rejected req
+  validateHandoff req | True  = Validated req p
+  validateHandoff req | False = Rejected req
 
 ||| Linearity Lemma: A handoff must consume the source Baton and produce a target one.
 ||| This proves that we never duplicate work during a handoff.
@@ -45,5 +45,5 @@ handoffPreservesLinearity :
   -> {auto nodePf : targetNode req = dst}
   -> HandoffResult req
   -> IsLinear b Executing -- Produces exactly one executing witness for the target
-handoffPreservesLinearity b src dst (InFlight b src) req (Validated req pf) = InFlight b dst
-handoffPreservesLinearity b src dst (InFlight b src) req (Rejected req)    = InFlight b src
+handoffPreservesLinearity b src dst (InFlight _ _) req (Validated _ _) = InFlight b dst
+handoffPreservesLinearity b src dst (InFlight _ _) req (Rejected _)    = InFlight b src

--- a/verification/proofs/Bag/Protocol.idr
+++ b/verification/proofs/Bag/Protocol.idr
@@ -5,7 +5,9 @@ module Bag.Protocol
 
 %default total
 
-||| Core hardware and identity capabilities.
+||| Core hardware, identity, and toolchain capabilities.
+||| Toolchain capabilities (Zig/Rust/Cargo/Deno) let a CI-check Baton be routed
+||| only to a node that actually has the toolchain the check needs.
 public export
 data Capability
   = Linux
@@ -14,6 +16,10 @@ data Capability
   | Guix
   | TrustedHost String
   | SecretAccess String
+  | Zig
+  | Rust
+  | Cargo
+  | Deno
 
 public export
 Eq Capability where
@@ -23,6 +29,10 @@ Eq Capability where
   Guix == Guix = True
   (TrustedHost s1) == (TrustedHost s2) = s1 == s2
   (SecretAccess s1) == (SecretAccess s2) = s1 == s2
+  Zig == Zig = True
+  Rust == Rust = True
+  Cargo == Cargo = True
+  Deno == Deno = True
   _ == _ = False
 
 ||| Check if a node's provided capabilities satisfy the Baton's requirements.
@@ -43,3 +53,7 @@ capToTag GPU              = 3
 capToTag Guix             = 4
 capToTag (TrustedHost _)  = 5
 capToTag (SecretAccess _) = 6
+capToTag Zig              = 7
+capToTag Rust             = 8
+capToTag Cargo            = 9
+capToTag Deno             = 10


### PR DESCRIPTION
## CI-check Baton — estate CI on owned compute

First implementation of the bag-of-actions thesis: run estate CI checks as **Batons** on owned compute with **zero GitHub Actions minutes**, routed only to capability-matched nodes, with frozen + attested verdicts. The check GitHub would refuse to start (billing wall / allow-list) runs anyway.

### Wired across Idris ↔ Zig ↔ Elixir
- **Idris (source of truth):** toolchain capabilities (Zig/Rust/Cargo/Deno) added to `Protocol.capToTag` + Estate manifest. Fixed 3 pre-existing build breaks so `idris2 --build bag.ipkg` is green (`List.find`→`Data.List`, `with`-clause shorthand, non-linear patterns).
- **Zig host:** `CheckBaton` (freeze/thaw + HMAC-SHA256 attestation); `check`/`thaw`/`nodes` subcommands; fail-safe capability match (unknown capability never matches).
- **Elixir:** `Bag.CiBaton`, `Executor.run_check`/`thaw_check`/`list_nodes`, `Bag.Mesh.submit_check` (routes through the orchestrator to a capability-matched node), `Bag.CiSweep` + `mix bag.sweep` tool + dogfood `ci-checks.exs`.

### Verification (all green, all local)
- `idris2 --build bag.ipkg` builds; 6 Zig tests (incl. tamper-detection); 11 Elixir tests + 1 doctest.
- `./scripts/ci-baton-demo.sh` and `mix bag.sweep` demonstrate pass / fail / suspend / thaw / tamper-reject.

### Notes
- Both commits SSH-signed with the estate signing key.
- This branch also carries the prior unpushed commit `482d52e` (security: TruffleHog) because `origin/main` did not have it yet.
- Remaining (separate): hypatia/ci-health bridge (runs on owned compute), real ed25519 attestation key, WASI-compiled check bodies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
