### PR TITLE
Estate · register hypatia brain node + merge-orchestration end-to-end test

### DIFF
--- a/bag/lib/bag/ci_baton.ex
+++ b/bag/lib/bag/ci_baton.ex
@@ -19,6 +19,7 @@ defmodule Bag.CiBaton do
     :command,
     :verdict,
     :exit_code,
+    artifact_path: nil,
     mutating: false,
     risk: :low
   ]
@@ -32,7 +33,8 @@ defmodule Bag.CiBaton do
           required_cap: String.t(),
           command: [String.t()],
           verdict: verdict(),
-          exit_code: integer() | nil
+          exit_code: integer() | nil,
+          artifact_path: String.t() | nil
         }
 
   @doc """
@@ -51,6 +53,7 @@ defmodule Bag.CiBaton do
       command: command,
       verdict: :pending,
       exit_code: nil,
+      artifact_path: Keyword.get(opts, :artifact_path),
       mutating: Keyword.get(opts, :mutating, false),
       risk: Keyword.get(opts, :risk, :low)
     }

--- a/bag/lib/bag/ci_sweep.ex
+++ b/bag/lib/bag/ci_sweep.ex
@@ -17,7 +17,11 @@ defmodule Bag.CiSweep do
     results =
       Enum.map(checks, fn check ->
         cap = Map.get(check, :required_cap, "linux")
-        {verdict, node, _baton} = Mesh.submit_check(check.check_id, check.command, required_cap: cap)
+        artifact_path = Map.get(check, :artifact_path)
+        {verdict, node, _baton} = Mesh.submit_check(check.check_id, check.command,
+          required_cap: cap,
+          artifact_path: artifact_path
+        )
         %{check_id: check.check_id, verdict: verdict, node: node}
       end)
 

--- a/bag/lib/bag/executor.ex
+++ b/bag/lib/bag/executor.ex
@@ -60,8 +60,14 @@ defmodule Bag.Executor do
   def run_check(%Bag.CiBaton{} = b, freeze_path) do
     args = ["check", b.node, b.required_cap, b.check_id, freeze_path | b.command]
 
-    {output, code} =
-      System.cmd(@executor_path, args, cd: Path.expand("../../../", __DIR__), stderr_to_stdout: true)
+    # Pass artifact path via env var so the Zig host can hash the report after
+    # the check runs and include its digest in the frozen Baton envelope.
+    base_opts = [cd: Path.expand("../../../", __DIR__), stderr_to_stdout: true]
+    opts = if b.artifact_path,
+      do: Keyword.put(base_opts, :env, [{"BAG_ARTIFACT_PATH", b.artifact_path}]),
+      else: base_opts
+
+    {output, code} = System.cmd(@executor_path, args, opts)
 
     verdict =
       case code do

--- a/bag/lib/bag/mesh.ex
+++ b/bag/lib/bag/mesh.ex
@@ -58,12 +58,18 @@ defmodule Bag.Mesh do
     valid_targets = Enum.filter(members, fn pid ->
       node_name = node_to_name(node(pid))
       # Translate requiredCap to string list for the Zig bridge
-      req_strings = Enum.map(baton.required_cap || [], fn 
+      req_strings = Enum.map(baton.required_cap || [], fn
         :guix -> "guix"
         :linux -> "linux"
         :macos -> "macos"
         :gpu -> "gpu"
         :trusted_host -> "trusted_host"
+        :zig -> "zig"
+        :rust -> "rust"
+        :cargo -> "cargo"
+        :deno -> "deno"
+        :scorecard -> "scorecard"
+        :wasm -> "wasm"
         _ -> "unknown"
       end)
       
@@ -98,6 +104,7 @@ defmodule Bag.Mesh do
   @impl true
   def handle_call({:submit_check, check_id, command, opts}, _from, state) do
     required_cap = Keyword.get(opts, :required_cap, "linux")
+    artifact_path = Keyword.get(opts, :artifact_path)
 
     freeze_path =
       Keyword.get(opts, :freeze_path, Path.join(System.tmp_dir!(), "#{check_id}.baton"))
@@ -114,7 +121,11 @@ defmodule Bag.Mesh do
         {:reply, {:suspended, nil, nil}, state}
 
       [node | _] ->
-        baton = CiBaton.new(check_id, command, node: node, required_cap: required_cap)
+        baton = CiBaton.new(check_id, command,
+          node: node,
+          required_cap: required_cap,
+          artifact_path: artifact_path
+        )
         IO.puts(:stderr, "Mesh: routing check #{check_id} → #{node} (cap: #{required_cap})")
         {verdict, updated, _output} = Executor.run_check(baton, freeze_path)
         IO.puts(:stderr, "Mesh: check #{check_id} verdict=#{verdict} on #{node} (0 GitHub minutes)")
@@ -133,7 +144,8 @@ defmodule Bag.Mesh do
             node: node,
             required_cap: spec.required_cap,
             mutating: Map.get(spec, :mutating, false),
-            risk: Map.get(spec, :risk, :low)
+            risk: Map.get(spec, :risk, :low),
+            artifact_path: Map.get(spec, :artifact_path)
           )
 
         freeze_path = Path.join(System.tmp_dir!(), "#{spec.check_id}.baton")

--- a/bag/test/merge_orchestration_e2e_test.exs
+++ b/bag/test/merge_orchestration_e2e_test.exs
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+defmodule Bag.MergeOrchestrationE2ETest do
+  @moduledoc """
+  End-to-end: a hypatia merge decision — shaped exactly as
+  `Hypatia.MergeOrchestration.BatonEmitter.to_spec/2` produces it — crosses into
+  the Bag-of-Actions mesh.
+
+  The decision FREEZES on the token-free brain (which lacks `secret_access`) and
+  MIGRATES to the token-bearing `mesh-github-runner`, which re-verifies and runs
+  the merge, returning a verdict + residue that feeds back as trust-chain
+  evidence. This is the capability-routed actuation backend the
+  `05-execution-substrate-bag-of-actions.adoc` design describes.
+
+  SAFETY: no real `gh pr merge` is ever executed. The merge command is replaced
+  by a harmless stand-in (`true`) so the routing / mutation-gate / freeze / thaw /
+  verdict path is exercised end to end without touching a real PR — and the brain
+  holds no token anyway. The real command shape is checked through the planner
+  only (which selects a node but executes nothing).
+  """
+  use ExUnit.Case, async: false
+  alias Bag.{Mesh, Planner, Budget, Executor}
+
+  @repo_root Path.expand("../..", __DIR__)
+  @exe Path.expand("zig-out/bin/bag_of_actions", Path.expand("../..", __DIR__))
+
+  setup_all do
+    {_out, 0} = System.cmd("zig", ["build"], cd: @repo_root, stderr_to_stdout: true)
+    :ok
+  end
+
+  # The exact spec shape hypatia's `BatonEmitter.to_spec/2` emits for an armed
+  # merge — `command` swapped for the caller's so the real `gh pr merge` shape and
+  # a safe stand-in can both be exercised.
+  defp merge_spec(command) do
+    %{
+      check_id: "merge-hyperpolymath__a-7",
+      command: command,
+      required_cap: "secret_access",
+      mutating: true,
+      verifier: %{
+        by: "git-private-farm:decide_action",
+        reverifies: %{authority_bot: "robot-repo-automaton", contributing_bots: ["ci"]}
+      },
+      risk: :low,
+      attestation: %{
+        lease_id: "lease-hyperpolymath-a-7",
+        route: %{authority_bot: "robot-repo-automaton", contributing_bots: ["ci"]},
+        method: "squash",
+        pool: "p2",
+        rationale: "chore/object -> arm_auto"
+      }
+    }
+  end
+
+  defp real_merge_command,
+    do: ["gh", "pr", "merge", "7", "--repo", "hyperpolymath/a", "--squash"]
+
+  test "the token-free brain cannot satisfy secret_access; only the runner can" do
+    refute Executor.node_satisfies?("mesh-hypatia-brain", ["secret_access"]),
+           "the brain must NOT hold secret_access (token-free-brain invariant)"
+
+    assert Executor.node_satisfies?("mesh-github-runner", ["secret_access"])
+  end
+
+  test "the real `gh pr merge` spec routes to the token-bearing runner (planner only — nothing run)" do
+    # Planner.plan selects a node but executes NOTHING, so it is safe to feed it
+    # the real merge command: it proves the routing without merging anything.
+    assert {:ok, "mesh-github-runner", 100} =
+             Planner.plan(merge_spec(real_merge_command()), Budget.unlimited())
+  end
+
+  test "a mutating merge with no verifier is rejected — defence in depth" do
+    no_verifier = merge_spec(["true"]) |> Map.delete(:verifier)
+
+    assert {:rejected, :mutation_requires_verifier} =
+             Planner.plan(no_verifier, Budget.unlimited())
+  end
+
+  test "submit_planned migrates the merge to the runner, runs it, returns verdict + clean residue" do
+    # safe stand-in for `gh pr merge` — full freeze/run/verdict path on the
+    # secret_access node, no real PR touched.
+    result = Mesh.submit_planned(merge_spec(["true"]), Budget.unlimited())
+
+    assert result.node == "mesh-github-runner"
+    assert result.verdict == :pass
+    # ran on the token/paid route (NOT relegated) -> it satisfied the real gate ->
+    # nothing owed: the trust-chain residue is clean.
+    assert result.residue == :clean
+  end
+
+  test "freeze on the brain (no token) -> thaw on the runner: the continuation hand-off" do
+    freeze =
+      Path.join(System.tmp_dir!(), "merge-e2e-#{System.unique_integer([:positive])}.baton")
+
+    # 1. Brain attempts the merge but LACKS secret_access -> work is SUSPENDED and
+    #    a PENDING baton is frozen so it can migrate (exit 2).
+    {brain_out, brain_code} =
+      System.cmd(
+        @exe,
+        ["check", "mesh-hypatia-brain", "secret_access", "merge-7", freeze, "true"],
+        cd: @repo_root,
+        stderr_to_stdout: true
+      )
+
+    assert brain_code == 2
+    assert brain_out =~ "VERDICT=suspended"
+    assert brain_out =~ "lacks capability"
+    assert File.exists?(freeze)
+
+    # 2. The runner HOLDS secret_access -> it runs the (safe stand-in) merge and
+    #    freezes the executed verdict (exit 0).
+    {runner_out, runner_code} =
+      System.cmd(
+        @exe,
+        ["check", "mesh-github-runner", "secret_access", "merge-7", freeze, "true"],
+        cd: @repo_root,
+        stderr_to_stdout: true
+      )
+
+    assert runner_code == 0
+    assert runner_out =~ "VERDICT=pass"
+
+    # 3. The verdict thaws on another node with ZERO re-execution; attestation
+    #    verifies -> this is the trust-chain residue fed back to the brain.
+    {thaw_out, thaw_code} =
+      System.cmd(@exe, ["thaw", freeze], cd: @repo_root, stderr_to_stdout: true)
+
+    assert thaw_code == 0
+    assert thaw_out =~ "VERDICT=pass"
+    assert thaw_out =~ "attestation=hmac:verified"
+
+    File.rm(freeze)
+  end
+end

--- a/build.zig
+++ b/build.zig
@@ -144,15 +144,23 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&run_mod_tests.step);
     test_step.dependOn(&run_exe_tests.step);
 
-    // Just like flags, top level steps are also listed in the `--help` menu.
-    //
-    // The Zig build system is entirely implemented in userland, which means
-    // that it cannot hook into private compiler APIs. All compilation work
-    // orchestrated by the build system will result in other Zig compiler
-    // subcommands being invoked with the right flags defined. You can observe
-    // these invocations when one fails (or you pass a flag to increase
-    // verbosity) to validate assumptions and diagnose problems.
-    //
-    // Lastly, the Zig build system is relatively simple and self-contained,
-    // and reading its source code will allow you to master it.
+    // WASI check modules: compile self-contained CI checks to wasm32-wasi so they
+    // can be frozen as Wasm Batons and executed via `wasmtime run --dir=. <module>`.
+    // Run with: `zig build wasm`
+    const wasi_target = b.resolveTargetQuery(.{
+        .cpu_arch = .wasm32,
+        .os_tag = .wasi,
+    });
+    const zig_fmt_wasm = b.addExecutable(.{
+        .name = "zig_fmt",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/checks/zig_fmt.zig"),
+            .target = wasi_target,
+            .optimize = .ReleaseSmall,
+        }),
+    });
+    const wasm_step = b.step("wasm", "Build WASI check modules to zig-out/lib/");
+    wasm_step.dependOn(&b.addInstallArtifact(zig_fmt_wasm, .{
+        .dest_dir = .{ .override = .{ .custom = "lib" } },
+    }).step);
 }

--- a/ci-checks.exs
+++ b/ci-checks.exs
@@ -14,5 +14,10 @@
     check_id: "zig-build-test",
     command: ["zig", "build", "test"],
     required_cap: "zig"
+  },
+  %{
+    check_id: "zig-fmt-wasm",
+    command: ["wasm://zig-out/lib/zig_fmt.wasm", "src/main.zig", "src/estate.zig", "src/root.zig"],
+    required_cap: "wasm"
   }
 ]

--- a/ci-checks.security.exs
+++ b/ci-checks.security.exs
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+#
+# Security CI manifest: external security-analysis tools run as Batons on owned
+# compute (zero GitHub Actions minutes). These checks require network access or
+# additional tooling beyond the base Zig toolchain, so they live in a separate
+# manifest from ci-checks.exs (the reliable local dogfood manifest).
+#
+# Run via:
+#   cd bag && mix bag.sweep ../ci-checks.security.exs
+#
+# OSSF Scorecard notes:
+#   - Requires GITHUB_AUTH_TOKEN in the environment (read-only PAT or GITHUB_TOKEN).
+#   - The wrapper script writes JSON output to _bag_artifacts/scorecard/scorecard.json.
+#   - The Zig host hashes that file and includes the digest in the frozen Baton.
+#   - `publish_results: true`, OSSF badge updates, and GitHub Security tab upload
+#     are separate publication concerns NOT handled by this Baton — they remain
+#     optional GitHub-native bridges run after the attested result is produced.
+#   - See docs/external-tool-batonisation.adoc for the general pattern.
+[
+  %{
+    check_id: "ossf-scorecard",
+    command: ["./scripts/baton-scorecard.sh", "github.com/hyperpolymath/bag-of-actions"],
+    required_cap: "scorecard",
+    artifact_path: "_bag_artifacts/scorecard/scorecard.json"
+  }
+]

--- a/docs/ci-check-baton.adoc
+++ b/docs/ci-check-baton.adoc
@@ -20,13 +20,25 @@ can carry mobile *CI work and its (tamper-evident) verdict*.
 [cols="1,3"]
 |===
 | `check_id`     | names the check, e.g. `zig-fmt`
-| `command`      | the argv to run, e.g. `zig fmt --check build.zig`
-| `required_cap` | the capability a node must have to run it (`linux`, `guix`, `zig`, `rust`, `cargo`, `deno`, …)
+| `command`      | the argv to run; `wasm://path` prefix triggers WASI execution via `wasmtime`
+| `required_cap` | the capability a node must have to run it (`linux`, `guix`, `zig`, `rust`, `cargo`, `deno`, `scorecard`, `wasm`, …)
 | `node`         | the node the work is routed to
 | `verdict`      | `pending` (frozen, not yet run) / `pass` / `fail`
 | `exit_code`    | the executed check's exit status
-| `digest`       | HMAC-SHA256 over the fields (keyed by `BAG_ATTEST_KEY`) — makes the verdict tamper-evident
+| `digest`       | HMAC-SHA256 over the canonical string (keyed by `BAG_ATTEST_KEY`) — integrity-evident
+| `signature`    | ed25519 signature over the same canonical string (hex-encoded, 128 chars) — authenticity-evident
+| `signing_pubkey` | raw ed25519 public key of the signing node (hex-encoded, 64 chars) — self-contained, no key lookup needed
+| `wasm_path`    | path to the WASM module (metadata); `wasm_digest` (SHA-256) is bound into the canonical string
+| `tool_version` | tool version string from `BAG_TOOL_VERSION` (e.g., `"scorecard 5.1.0"`) — bound into canonical string
+| `artifact_inline_b64` | small artifact base64-inlined if ≤ `BAG_ARTIFACT_INLINE_MAX` bytes (default 4096)
 |===
+
+Both attestation fields are optional per-envelope.
+`digest` is always computed.
+`signature` + `signing_pubkey` are present when the executing node has a signing key
+(`BAG_SIGN_KEY_PATH` env var, or `~/.ssh/id_ed25519_signing` by default).
+On thaw: if both layers are present, both must verify; if only HMAC is present, only HMAC is verified.
+The estate signing key is `id_ed25519_signing` — `id_ed25519` is auth-only and *must not* be used here.
 
 Lifecycle:
 
@@ -46,6 +58,31 @@ The capability taxonomy is kept in step across THREE layers — add a capability
 in `Protocol.idr` (`capToTag`) AND `estate.Capability` (Zig) AND the Elixir
 translation, or in none. The Elixir orchestrator reads the node list from the
 single mirrored manifest via `bag_of_actions nodes` (no 4th copy to drift).
+
+An *unknown/unprovable* capability string never matches any node — the `match`
+subcommand exits 1 and the Elixir orchestrator suspends the check.
+
+== External tools as Baton payloads
+
+CI/security tools that ship as a CLI, container, or stable binary can be run _as
+a Baton payload_ without reimplementing their semantics. The Actions wrapper that
+GitHub normally provides is not the unit being replaced — the underlying executable
+is.
+
+*OSSF Scorecard* is the first worked example:
+
+* The `ossf/scorecard-action` wrapper is NOT reimplemented.
+* The `scorecard` CLI (or `ghcr.io/ossf/scorecard:latest` container) is the
+  executable payload — it runs on a `scorecard`-capable node via
+  `scripts/baton-scorecard.sh`.
+* The JSON result is written to `_bag_artifacts/scorecard/scorecard.json`; the Zig
+  host hashes it and includes the SHA-256 in the frozen Baton envelope.
+* Publication to the OSSF API, GitHub Security tab (SARIF), and OSSF badge remain
+  separate cloud-native bridges — they are not replaced by this Batonisation.
+
+The general classification (Batonisable executable / split-boundary tool / native
+Baton candidate / not Batonisable yet) and the ten Batonisation rules live in
+`docs/external-tool-batonisation.adoc`.
 
 == Run it
 
@@ -90,20 +127,29 @@ other nodes trust. The check that GitHub would have refused to start runs anyway
 
 Done (wired across Idris ↔ Zig ↔ Elixir):
 
-* Toolchain capability taxonomy (`Zig`/`Rust`/`Cargo`/`Deno`), mirrored in all
-  three layers; dev nodes carry the toolchain caps.
-* Attestation: HMAC-SHA256 digest, verified on thaw, tamper rejected.
+* Toolchain capability taxonomy (`Zig`/`Rust`/`Cargo`/`Deno`/`Scorecard`/`Wasm`),
+  mirrored in all three layers; dev nodes carry the toolchain caps.
+* Attestation: dual-layer (HMAC-SHA256 integrity + ed25519 authenticity). Thaw
+  rejects if either present layer fails. `BAG_SIGN_KEY_PATH` / `~/.ssh/id_ed25519_signing`
+  is the per-node signing key; unsigned Batons (HMAC-only) remain valid.
 * `CiBaton` wired into `Bag.Mesh` (`submit_check`) + the `Bag.CiSweep` batch emitter.
 * Fail-safe matching (unknown capability never matches).
-* Formal layer now compiles (`idris2 --build bag.ipkg` — three pre-existing
-  breaks fixed: `List.find`, `with`-clause shorthand, non-linear patterns).
+* Formal layer now compiles (`idris2 --build bag.ipkg`).
+* `hypatia/scripts/ci-health/run.sh` calls `Bag.CiSweep.run/1` for the estate's
+  CI checks — zero GitHub minutes; sitrep reads the cached JSON verdict.
+* External tool Batonisation pattern: Scorecard as first worked example
+  (`scripts/baton-scorecard.sh` exports `BAG_TOOL_VERSION`).
+* WASI-compile self-contained checks: `src/checks/zig_fmt.zig` compiles to
+  `wasm32-wasi` (`zig build wasm` → `zig-out/lib/zig_fmt.wasm`). The `wasm://`
+  command prefix routes execution through `wasmtime run --dir=.`; the wasm module
+  SHA-256 (`wasm_digest`) is bound into the canonical string and attested.
+* Artifact-bearing CheckBaton v2: `tool_version` (`BAG_TOOL_VERSION`),
+  `artifact_inline_b64` (≤`BAG_ARTIFACT_INLINE_MAX` bytes inline as base64),
+  all bound into the canonical string so tampering is detected on thaw.
+  `ci-checks.exs` ships a `zig-fmt-wasm` check that exercises the full path.
 
 Next:
 
-* *Cross-repo (push-gated):* bridge `hypatia/scripts/ci-health` to call
-  `Bag.CiSweep.run/1` for the estate's real checks instead of flagging GitHub
-  failures.
-* Replace the HMAC dev key with real per-node signing (ed25519 / the estate
-  signing key) so a thawed verdict is authenticity-evident, not just integrity-evident.
-* WASI-compile self-contained checks so the check body itself is a frozen Wasm
-  Baton (the purest form of the model).
+* Multi-artifact support (SARIF → structured residue, parallel artifact binding).
+* WASM module distribution (ship check modules with the estate; hash-pin them
+  in the manifest so the wasm_digest is a content-addressed reference).

--- a/docs/external-tool-batonisation.adoc
+++ b/docs/external-tool-batonisation.adoc
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+= External-tool Batonisation
+:toc: preamble
+:icons: font
+
+External CI/security tools should not be reimplemented merely because they are
+currently consumed through a GitHub Actions wrapper.
+
+Before deciding to reimplement, classify the tool — then apply the appropriate
+Batonisation pattern.
+
+== Classification
+
+[cols="1,3,2"]
+|===
+| Class | Characteristics | Approach
+
+| *Batonisable executable*
+| Has a CLI, container image, or stable binary. Returns a process exit code and/or
+  machine-readable report. Can run on owned compute with explicit capabilities.
+  The Actions wrapper is orchestration/publishing sugar around the real executable.
+| Run as a CI-check Baton. Freeze verdict + report digest.
+
+| *Split-boundary tool*
+| Has a pure local analysis part and a GitHub/cloud-native publication part.
+  Example: OSSF Scorecard (local scan vs. OSSF API upload + badge + SARIF upload).
+| Batonise the scan/report generation. Keep a minimal bridge _only_ if
+  GitHub-native publication is actually required.
+
+| *Native Baton candidate*
+| No usable executable or API boundary. Semantics are small, strategic, or require
+  proof-carrying native behaviour.
+| Implement as a native Baton with proofs/tests. Do not wrap a reimplementation.
+
+| *Not Batonisable yet*
+| Requires interactive browser/session state, non-reproducible SaaS-only execution,
+  unstable outputs, or hidden side effects.
+| Write an adapter/proxy first, or keep it outside the Baton trust path.
+|===
+
+== Rules
+
+. *Prefer wrapping a stable CLI/container/API over reimplementing semantics.*
+  The Actions wrapper is not the tool — find the underlying executable.
+
+. *Freeze the verdict, command, version, relevant inputs, and report digest.*
+  The Baton envelope is the tamper-evident record; the exit code alone is not.
+
+. *Separate execution from publication.*
+  Running the tool on owned compute and uploading results to an external API are
+  independent concerns. Do not conflate them in the Baton.
+
+. *Keep cloud/GitHub-native identity bridges thin and explicit.*
+  OIDC tokens, SARIF uploads, and badge updates stay outside the Baton envelope;
+  reference them in docs, not in the verdict logic.
+
+. *Add capabilities for actual execution requirements, not brand names.*
+  `scorecard` means "this node can run the Scorecard CLI or container". Prefer
+  operational names over product names where possible (e.g. `container` for any
+  Docker-capable node).
+
+. *Fail closed on unknown capabilities.*
+  An unknown/unprovable capability string in `Capability.fromString` returns `null`
+  and the `match` subcommand exits 1. No fallback to `linux` or any default.
+
+. *Prefer pinned versions for trust-sensitive scans.*
+  Record the tool version in the frozen Baton `command` field (e.g.
+  `scorecard --repo=... --show-details`) or in a companion version file attested
+  alongside the report.
+
+. *Attest results before migration/thaw.*
+  The HMAC-SHA256 digest covers the verdict fields and, when present, the report's
+  SHA-256. Thawing without a valid attestation exits 3 (tampered).
+
+. *Do not hide external nondeterminism; record it.*
+  Tools like Scorecard query live databases. Record the scan timestamp, tool
+  version, and ruleset/DB version in the report or in companion metadata so the
+  Baton can be understood in isolation.
+
+. *Only reimplement when semantics are small, strategic, unavailable as an
+   executable, or require proof-carrying native behaviour.*
+   If a reimplementation would be equivalent to the upstream tool, don't.
+
+== Worked example: OSSF Scorecard
+
+=== Why Scorecard is a split-boundary tool
+
+OSSF Scorecard has two distinct phases:
+
+* *Local scan* — the `scorecard` CLI (or `ghcr.io/ossf/scorecard:latest` container)
+  queries the repository, runs checks, and writes a JSON or SARIF report to disk.
+  This phase runs entirely on owned compute with a read-only GitHub token.
+
+* *Cloud publication* — `publish_results: true` uploads the result to the OSSF API
+  (feeds the badge); a separate SARIF upload step populates the GitHub Security tab.
+  These use GitHub OIDC identity and are inherently cloud-native.
+
+The official `ossf/scorecard-action` wrapper orchestrates both phases in a single
+Actions step. The Baton wraps only the first phase; the second remains a thin bridge.
+
+=== Scorecard capability
+
+`scorecard` was added to the capability taxonomy (tag 11) alongside `zig`, `rust`,
+`cargo`, and `deno`. It is currently assigned to `mesh-server-1`.
+
+The three-layer sync rule applies:
+
+[source]
+----
+verification/proofs/Bag/Protocol.idr  →  | Scorecard   (capToTag = 11)
+src/estate.zig                         →  scorecard = 11
+bag/lib/bag/mesh.ex                    →  :scorecard -> "scorecard"
+----
+
+=== Manifest
+
+`ci-checks.security.exs` contains the Scorecard check:
+
+[source,elixir]
+----
+%{
+  check_id: "ossf-scorecard",
+  command: ["./scripts/baton-scorecard.sh", "github.com/hyperpolymath/bag-of-actions"],
+  required_cap: "scorecard",
+  artifact_path: "_bag_artifacts/scorecard/scorecard.json"
+}
+----
+
+Run it:
+
+[source,sh]
+----
+GITHUB_AUTH_TOKEN=<read-only-pat> cd bag && mix bag.sweep ../ci-checks.security.exs
+----
+
+=== Wrapper script
+
+`scripts/baton-scorecard.sh` is the stable interface between the Baton system and
+the Scorecard CLI. It:
+
+* Ensures `_bag_artifacts/scorecard/` exists.
+* Runs `scorecard --repo=... --format=json --show-details`.
+* Writes output to `_bag_artifacts/scorecard/scorecard.json`.
+* Returns Scorecard's exit code unmodified (no invented thresholds by default).
+* Optionally gates on `BAG_SCORECARD_MIN_SCORE` (0–10).
+
+Container alternative (when `scorecard` binary is not installed):
+
+[source,sh]
+----
+docker run --rm \
+  -e GITHUB_AUTH_TOKEN \
+  ghcr.io/ossf/scorecard:latest \
+  --repo=github.com/hyperpolymath/bag-of-actions \
+  --format=json \
+  --show-details \
+  > _bag_artifacts/scorecard/scorecard.json
+----
+
+Add a `container` capability to a node and update the manifest `command` if using
+this route.
+
+=== Artifact attestation
+
+The Zig `check` subcommand reads `BAG_ARTIFACT_PATH` (set by the Elixir executor
+when the manifest entry carries `artifact_path`). After the check runs, it computes
+a SHA-256 of the report file and includes the hex digest in the frozen Baton
+envelope:
+
+[source]
+----
+BAG-CHECK-BATON v1
+...
+digest=hmac-sha256:<hmac over verdict fields + artifact_sha256>
+artifact_path=_bag_artifacts/scorecard/scorecard.json
+artifact_sha256=<hex-sha256 of scorecard.json>
+----
+
+The HMAC covers both the verdict and the artifact digest, so tampering with either
+is rejected on thaw. Old Batons without `artifact_sha256` verify with the original
+canonical string (backward compatible).
+
+=== What this Baton does NOT replace
+
+[cols="1,2"]
+|===
+| Concern | Remains a GitHub/OSSF-native bridge
+
+| `publish_results: true`
+| OSSF API upload (feeds badge). Requires GitHub OIDC identity. Not in Baton.
+
+| GitHub Security tab
+| SARIF upload via `github/codeql-action/upload-sarif`. Not in Baton.
+
+| OSSF badge
+| Populated by the OSSF API from `publish_results`. Not in Baton.
+|===
+
+== Future candidates
+
+[cols="1,2,1"]
+|===
+| Tool | Batonisation approach | Capability
+
+| CodeQL CLI
+| `codeql database analyze --format=sarif-latest` → SARIF Baton
+| `codeql`
+
+| Trivy / Grype
+| `trivy image --format json` → vulnerability Baton
+| `container`
+
+| Syft
+| `syft ... --output cyclonedx-json` → SBOM Baton
+| `container`
+
+| cargo-audit / cargo-deny
+| `cargo audit --json` → Rust security-policy Baton
+| `cargo`
+
+| semgrep
+| `semgrep --config auto --json` → ruleset-bound SARIF Baton
+| `semgrep`
+
+| cosign / slsa-verifier
+| `cosign verify ...` → provenance verification Baton
+| `trusted_host`
+|===
+
+For each: find the CLI boundary, add the capability, write a thin wrapper script,
+add the manifest entry, and let the existing freeze/thaw/attest pipeline handle
+the rest.
+
+== Artifact-bearing CheckBaton v2 (TODO)
+
+The current artifact support (v1) hashes the artifact file and binds the digest
+to the Baton attestation. Planned enhancements:
+
+* *Inline small artifacts* — for reports below a size threshold, embed them
+  directly in the Baton envelope (base64) to avoid a separate file.
+* *SARIF → structured Baton* — parse the SARIF `results` array and surface
+  findings as typed `ActionResult` residue, not just a file digest.
+* *Version pinning* — record tool version and ruleset/DB version in the envelope
+  so the Baton is reproducible evidence, not just a point-in-time snapshot.
+* *Multi-artifact* — support multiple artifact paths in a single Baton (e.g.,
+  JSON + SARIF + SBOM from a single scan run).

--- a/nodes.scm
+++ b/nodes.scm
@@ -19,7 +19,14 @@
     (owner . "Core-Infrastructure"))
   '((name . "mesh-github-runner")
     (capabilities . (linux secret-access))
-    (owner . "GitHub")))
+    (owner . "GitHub"))
+  ;; The hypatia "brain" (Elixir merge-orchestration host): emits/reads only and
+  ;; deliberately WITHOUT secret-access, so a merge Baton (required-cap
+  ;; secret-access) can never run here and must migrate to mesh-github-runner —
+  ;; the token-free-brain invariant. Mirrors src/estate.zig / Bag.Estate.idr.
+  '((name . "mesh-hypatia-brain")
+    (capabilities . (linux trusted-host))
+    (owner . "Jonathan")))
 
 ;; Note: In a production Guix System deployment, this would
 ;; be used to generate node-specific operating-system configurations.

--- a/scripts/baton-scorecard.sh
+++ b/scripts/baton-scorecard.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+#
+# baton-scorecard.sh — Run OSSF Scorecard as a Baton payload.
+#
+# This wrapper is the stable interface between the Baton system and the
+# Scorecard CLI. It ensures a deterministic output path so the Zig host
+# can hash the report and include the digest in the frozen Baton envelope.
+#
+# Usage:
+#   ./scripts/baton-scorecard.sh [REPO]
+#
+# REPO defaults to github.com/hyperpolymath/bag-of-actions.
+#
+# Environment:
+#   GITHUB_AUTH_TOKEN  Required. A read-only PAT (or GITHUB_TOKEN in CI).
+#                      Scorecard uses it to query the GitHub API.
+#   BAG_SCORECARD_MIN_SCORE  Optional. If set, exit 1 when the aggregate
+#                             score is below this value (0–10). Default:
+#                             preserve Scorecard's own exit code (no threshold).
+#
+# Output:
+#   _bag_artifacts/scorecard/scorecard.json  Machine-readable results.
+#
+# Exit codes (passed through from Scorecard unless BAG_SCORECARD_MIN_SCORE is set):
+#   0  Scorecard ran successfully.
+#   1  Scorecard reported a failure or the score is below the configured threshold.
+#
+# NOT handled here (separate publication concerns):
+#   - publish_results: true / OSSF API upload
+#   - GitHub Security tab (SARIF upload via github/codeql-action/upload-sarif)
+#   - OSSF badge updates
+#
+# See docs/external-tool-batonisation.adoc for the general pattern.
+set -euo pipefail
+
+REPO="${1:-github.com/hyperpolymath/bag-of-actions}"
+ARTIFACT_DIR="_bag_artifacts/scorecard"
+ARTIFACT_PATH="${ARTIFACT_DIR}/scorecard.json"
+
+mkdir -p "${ARTIFACT_DIR}"
+
+if ! command -v scorecard &>/dev/null; then
+  echo "baton-scorecard: 'scorecard' CLI not found." >&2
+  echo "Install via: go install sigs.k8s.io/scorecard/v5/cmd/scorecard@latest" >&2
+  echo "Or run via container: see docs/external-tool-batonisation.adoc" >&2
+  exit 1
+fi
+
+echo "baton-scorecard: running Scorecard for ${REPO}" >&2
+# Export version so the Zig host can bind it to the Baton canonical string.
+export BAG_TOOL_VERSION="scorecard $(scorecard version 2>&1 | head -1)"
+scorecard \
+  --repo="${REPO}" \
+  --format=json \
+  --show-details \
+  >"${ARTIFACT_PATH}"
+
+EXIT_CODE=$?
+
+if [[ ${EXIT_CODE} -ne 0 ]]; then
+  echo "baton-scorecard: Scorecard exited with code ${EXIT_CODE}" >&2
+  exit "${EXIT_CODE}"
+fi
+
+echo "baton-scorecard: results written to ${ARTIFACT_PATH}" >&2
+
+# Optional score threshold gate.
+if [[ -n "${BAG_SCORECARD_MIN_SCORE:-}" ]]; then
+  SCORE=$(jq -r '.score // empty' "${ARTIFACT_PATH}" 2>/dev/null || echo "")
+  if [[ -z "${SCORE}" ]]; then
+    echo "baton-scorecard: could not parse .score from ${ARTIFACT_PATH}" >&2
+    exit 1
+  fi
+  # Use awk for float comparison (bash arithmetic is integers only).
+  if awk "BEGIN { exit (${SCORE} >= ${BAG_SCORECARD_MIN_SCORE}) ? 0 : 1 }"; then
+    echo "baton-scorecard: score ${SCORE} >= ${BAG_SCORECARD_MIN_SCORE} (threshold met)" >&2
+  else
+    echo "baton-scorecard: score ${SCORE} < ${BAG_SCORECARD_MIN_SCORE} (threshold NOT met)" >&2
+    exit 1
+  fi
+fi

--- a/src/checks/zig_fmt.zig
+++ b/src/checks/zig_fmt.zig
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+//
+// WASI check: verify that all listed .zig files are `zig fmt`-clean.
+// This module compiles to wasm32-wasi and runs via:
+//   wasmtime run --dir=. zig-out/lib/zig_fmt.wasm <file.zig> [file.zig...]
+//
+// Exit 0 = all files are formatted; 1 = at least one needs formatting or parse error.
+// Unformatted file names are printed to stdout (one per line), errors to stderr.
+const std = @import("std");
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    const args = try std.process.argsAlloc(allocator);
+    defer std.process.argsFree(allocator, args);
+
+    if (args.len < 2) {
+        try std.fs.File.stderr().writeAll("usage: zig_fmt.wasm <file.zig> [file.zig...]\n");
+        std.process.exit(1);
+    }
+
+    var all_ok = true;
+    for (args[1..]) |path| {
+        const ok = checkFile(allocator, path) catch |err| {
+            const msg = try std.fmt.allocPrint(allocator, "zig_fmt: {s}: {s}\n", .{ path, @errorName(err) });
+            defer allocator.free(msg);
+            try std.fs.File.stderr().writeAll(msg);
+            all_ok = false;
+            continue;
+        };
+        if (!ok) {
+            const msg = try std.fmt.allocPrint(allocator, "needs formatting: {s}\n", .{path});
+            defer allocator.free(msg);
+            try std.fs.File.stdout().writeAll(msg);
+            all_ok = false;
+        }
+    }
+    std.process.exit(if (all_ok) 0 else 1);
+}
+
+fn checkFile(allocator: std.mem.Allocator, path: []const u8) !bool {
+    const source_raw = try std.fs.cwd().readFileAlloc(allocator, path, 1 * 1024 * 1024);
+    defer allocator.free(source_raw);
+
+    // Ast.parse requires a null-terminated source. Allocate a buffer with sentinel.
+    const buf = try allocator.alloc(u8, source_raw.len + 1);
+    defer allocator.free(buf);
+    @memcpy(buf[0..source_raw.len], source_raw);
+    buf[source_raw.len] = 0;
+    const source: [:0]const u8 = buf[0..source_raw.len :0];
+
+    var tree = try std.zig.Ast.parse(allocator, source, .zig);
+    defer tree.deinit(allocator);
+
+    if (tree.errors.len > 0) return false;
+
+    const rendered = try tree.renderAlloc(allocator);
+    defer allocator.free(rendered);
+
+    return std.mem.eql(u8, source[0..source.len], rendered);
+}

--- a/src/estate.zig
+++ b/src/estate.zig
@@ -15,6 +15,8 @@ pub const Capability = enum(u32) {
     rust = 8,
     cargo = 9,
     deno = 10,
+    scorecard = 11,
+    wasm = 12,
 
     pub fn fromString(s: []const u8) ?Capability {
         if (std.mem.eql(u8, s, "linux")) return .linux;
@@ -27,6 +29,8 @@ pub const Capability = enum(u32) {
         if (std.mem.eql(u8, s, "rust")) return .rust;
         if (std.mem.eql(u8, s, "cargo")) return .cargo;
         if (std.mem.eql(u8, s, "deno")) return .deno;
+        if (std.mem.eql(u8, s, "scorecard")) return .scorecard;
+        if (std.mem.eql(u8, s, "wasm")) return .wasm;
         return null;
     }
 };
@@ -48,7 +52,7 @@ pub const estate = [_]Node{
     },
     .{
         .name = "mesh-server-1",
-        .capabilities = &[_]Capability{ .linux, .gpu, .guix, .trusted_host, .zig, .rust, .cargo, .deno },
+        .capabilities = &[_]Capability{ .linux, .gpu, .guix, .trusted_host, .zig, .rust, .cargo, .deno, .scorecard, .wasm },
         .cost = 1,
     },
     .{
@@ -67,7 +71,7 @@ pub fn findNode(name: []const u8) ?Node {
 
 pub fn nodeSatisfies(node_name: []const u8, requirements: []const Capability) bool {
     const node = findNode(node_name) orelse return false;
-    
+
     for (requirements) |req| {
         var found = false;
         for (node.capabilities) |cap| {

--- a/src/estate.zig
+++ b/src/estate.zig
@@ -60,6 +60,17 @@ pub const estate = [_]Node{
         .capabilities = &[_]Capability{ .linux, .secret_access },
         .cost = 100,
     },
+    // The hypatia "brain": the Elixir merge-orchestration host. It emits/reads
+    // only — it deliberately LACKS `secret_access`, so a merge Baton (whose
+    // required_cap is `secret_access`) can never execute here and must migrate to
+    // `mesh-github-runner`. The token-free-brain invariant as a capability fact.
+    // Owned + cheap; cost is moot for merges (never feasible for secret_access
+    // work). Mirrors Estate.idr / nodes.scm.
+    .{
+        .name = "mesh-hypatia-brain",
+        .capabilities = &[_]Capability{ .linux, .trusted_host },
+        .cost = 1,
+    },
 };
 
 pub fn findNode(name: []const u8) ?Node {

--- a/src/main.zig
+++ b/src/main.zig
@@ -55,11 +55,25 @@ pub const Verdict = enum {
     }
 };
 
+/// Hex-encoded ed25519 signature + signing public key produced by `signEd25519WithSeed`.
+const Ed25519Result = struct { sig: [128]u8, pubkey: [64]u8 };
+
 /// A CI-check Baton: a mobile unit of CI work that names a check, declares the
 /// capability a node must have to run it, and — once executed — freezes the
 /// verdict so it can migrate to (and be consumed on) another node WITHOUT
 /// re-running the check. This is the bag-of-actions answer to paid CI minutes:
 /// the check runs on owned compute, and the verdict is the portable artifact.
+///
+/// Attestation layers:
+///   1. HMAC-SHA256 (shared key, BAG_ATTEST_KEY): integrity-evident.
+///   2. ed25519 (per-node private key, BAG_SIGN_KEY_PATH): authenticity-evident.
+///      Only the private-key holder can produce a valid ed25519 signature;
+///      thaw verifies both layers and rejects if either fails.
+///      Old envelopes without the ed25519 fields remain fully valid (backward compat).
+///
+/// Optional artifact support: if the check writes a report file (e.g. a Scorecard
+/// JSON result), set `artifact_path` and `artifact_sha256`. The sha256 is included
+/// in both HMAC and ed25519 canonical strings, binding the report to the Baton.
 pub const CheckBaton = struct {
     id: []const u8,
     check_id: []const u8,
@@ -69,17 +83,62 @@ pub const CheckBaton = struct {
     exit_code: i32,
     command: []const u8,
     digest: [64]u8 = [_]u8{'0'} ** 64,
+    /// Path where the check wrote its report (metadata only — not attested directly).
+    artifact_path: ?[]const u8 = null,
+    /// Hex-encoded SHA-256 of the artifact file. Included in both HMAC and ed25519
+    /// canonical strings when non-null; tampering with the report is detected on thaw.
+    artifact_sha256: ?[64]u8 = null,
+    /// Hex-encoded ed25519 signature (64 bytes → 128 hex chars). Produced by the
+    /// executing node's private key (BAG_SIGN_KEY_PATH / ~/.ssh/id_ed25519_signing).
+    /// Makes the frozen verdict authenticity-evident in addition to HMAC integrity.
+    /// Absent on Batons from nodes without a signing key — thaw accepts both cases.
+    signature: ?[128]u8 = null,
+    /// Hex-encoded raw ed25519 public key of the signer (32 bytes → 64 hex chars).
+    /// Self-contained: verifiers do not need an out-of-band key lookup.
+    signing_pubkey: ?[64]u8 = null,
+    /// Path to the WASI module that executed this check (metadata — not attested inline).
+    wasm_path: ?[]const u8 = null,
+    /// Hex-encoded SHA-256 of the WASI module binary. Included in canonical string when
+    /// non-null so tampering with the module is detected on thaw.
+    wasm_digest: ?[64]u8 = null,
+    /// Tool version string (e.g., "scorecard 5.1.0") from BAG_TOOL_VERSION.
+    /// Included in canonical string when non-null — binds the version to the verdict.
+    tool_version: ?[]const u8 = null,
+    /// Small artifact inlined as standard base64 (file ≤ BAG_ARTIFACT_INLINE_MAX bytes).
+    /// Allows consumers to inspect the report without a separate file transfer.
+    artifact_inline_b64: ?[]const u8 = null,
 
-    /// HMAC-SHA256 over the verdict-bearing fields, hex-encoded. Makes a frozen
-    /// verdict tamper-evident: another node recomputes this with the shared key
-    /// and rejects the Baton if it does not match. (Integrity/authenticity hook;
-    /// the key comes from BAG_ATTEST_KEY — see `attestKey`.)
-    pub fn digestHex(self: CheckBaton, allocator: std.mem.Allocator, key: []const u8) ![64]u8 {
-        const canon = try std.fmt.allocPrint(
+    /// Build the canonical string that both HMAC and ed25519 sign over.
+    /// Optional extensions are appended in a defined order; absent fields are omitted
+    /// so old envelopes (which lack later extensions) remain valid.
+    /// Format: id|check_id|node|cap|verdict|exit|cmd[|sha256][|wasm:wasm_sha256][|tv:version]
+    pub fn canonicalString(self: CheckBaton, allocator: std.mem.Allocator) ![]u8 {
+        var s = try std.fmt.allocPrint(
             allocator,
             "{s}|{s}|{s}|{s}|{s}|{d}|{s}",
             .{ self.id, self.check_id, self.node, @tagName(self.required_cap), @tagName(self.verdict), self.exit_code, self.command },
         );
+        if (self.artifact_sha256) |sha| {
+            const prev = s;
+            s = try std.fmt.allocPrint(allocator, "{s}|{s}", .{ prev, sha[0..] });
+            allocator.free(prev);
+        }
+        if (self.wasm_digest) |wd| {
+            const prev = s;
+            s = try std.fmt.allocPrint(allocator, "{s}|wasm:{s}", .{ prev, wd[0..] });
+            allocator.free(prev);
+        }
+        if (self.tool_version) |tv| {
+            const prev = s;
+            s = try std.fmt.allocPrint(allocator, "{s}|tv:{s}", .{ prev, tv });
+            allocator.free(prev);
+        }
+        return s;
+    }
+
+    /// HMAC-SHA256 over the canonical string, hex-encoded.
+    pub fn digestHex(self: CheckBaton, allocator: std.mem.Allocator, key: []const u8) ![64]u8 {
+        const canon = try self.canonicalString(allocator);
         defer allocator.free(canon);
 
         const HmacSha256 = std.crypto.auth.hmac.sha2.HmacSha256;
@@ -95,25 +154,122 @@ pub const CheckBaton = struct {
         return hex;
     }
 
-    /// Recompute the digest and compare it to the one carried in the envelope.
+    /// Recompute the HMAC digest and compare it to the one in the envelope.
     pub fn verify(self: CheckBaton, allocator: std.mem.Allocator, key: []const u8) !bool {
         const expected = try self.digestHex(allocator, key);
         return std.mem.eql(u8, expected[0..], self.digest[0..]);
     }
 
-    /// Freeze the Baton (incl. its verdict + attestation digest) to a versioned
-    /// text envelope.
+    /// Sign the canonical string with the given 32-byte ed25519 seed.
+    /// Returns hex-encoded (signature, public-key) pair.
+    pub fn signEd25519WithSeed(self: CheckBaton, allocator: std.mem.Allocator, seed: [32]u8) !Ed25519Result {
+        const canon = try self.canonicalString(allocator);
+        defer allocator.free(canon);
+
+        const Ed25519 = std.crypto.sign.Ed25519;
+        const kp = try Ed25519.KeyPair.generateDeterministic(seed);
+        const sig = try kp.sign(canon, null); // null noise = deterministic
+        const sig_bytes = sig.toBytes();
+        const pk_bytes = kp.public_key.toBytes();
+
+        const hexchars = "0123456789abcdef";
+        var sig_hex: [128]u8 = undefined;
+        for (sig_bytes, 0..) |byte, i| {
+            sig_hex[i * 2] = hexchars[byte >> 4];
+            sig_hex[i * 2 + 1] = hexchars[byte & 0x0f];
+        }
+        var pk_hex: [64]u8 = undefined;
+        for (pk_bytes, 0..) |byte, i| {
+            pk_hex[i * 2] = hexchars[byte >> 4];
+            pk_hex[i * 2 + 1] = hexchars[byte & 0x0f];
+        }
+        return .{ .sig = sig_hex, .pubkey = pk_hex };
+    }
+
+    /// Sign the canonical string using the OpenSSH private key at `key_path`.
+    /// Defaults to BAG_SIGN_KEY_PATH, falling back to ~/.ssh/id_ed25519_signing.
+    /// Key must be unencrypted ed25519 (the estate signing key, NOT the auth key).
+    pub fn signEd25519(self: CheckBaton, allocator: std.mem.Allocator, key_path: []const u8) !Ed25519Result {
+        const seed = try readEd25519Seed(allocator, key_path);
+        return self.signEd25519WithSeed(allocator, seed);
+    }
+
+    /// Verify the ed25519 signature carried in this Baton against its stored public key.
+    /// Returns `false` (not an error) if no signature is present — caller decides policy.
+    /// Returns `false` on invalid signature or malformed fields.
+    pub fn verifyEd25519(self: CheckBaton, allocator: std.mem.Allocator) !bool {
+        const sig_hex = self.signature orelse return false;
+        const pk_hex = self.signing_pubkey orelse return false;
+
+        var sig_bytes: [64]u8 = undefined;
+        hexDecode(&sig_bytes, sig_hex[0..]) catch return false;
+        var pk_bytes: [32]u8 = undefined;
+        hexDecode(&pk_bytes, pk_hex[0..]) catch return false;
+
+        const canon = try self.canonicalString(allocator);
+        defer allocator.free(canon);
+
+        const Ed25519 = std.crypto.sign.Ed25519;
+        const pk = Ed25519.PublicKey.fromBytes(pk_bytes) catch return false;
+        const sig = Ed25519.Signature.fromBytes(sig_bytes);
+        sig.verify(canon, pk) catch return false;
+        return true;
+    }
+
+    /// Freeze the Baton (verdict + HMAC + optional ed25519 signature) to a versioned
+    /// text envelope. Fields are appended in order so parsers that stop at `digest`
+    /// remain compatible with older envelopes.
     pub fn freeze(self: CheckBaton, allocator: std.mem.Allocator, path: []const u8, key: []const u8) !void {
         const dh = try self.digestHex(allocator, key);
         const file = try std.fs.cwd().createFile(path, .{});
         defer file.close();
-        const msg = try std.fmt.allocPrint(
+        const base = try std.fmt.allocPrint(
             allocator,
             "BAG-CHECK-BATON v1\nid={s}\ncheck_id={s}\nnode={s}\nrequired_cap={s}\nverdict={s}\nexit_code={d}\ncommand={s}\ndigest=hmac-sha256:{s}\n",
             .{ self.id, self.check_id, self.node, @tagName(self.required_cap), @tagName(self.verdict), self.exit_code, self.command, dh[0..] },
         );
-        defer allocator.free(msg);
-        try file.writeAll(msg);
+        defer allocator.free(base);
+        try file.writeAll(base);
+        if (self.artifact_path) |ap| {
+            const line = try std.fmt.allocPrint(allocator, "artifact_path={s}\n", .{ap});
+            defer allocator.free(line);
+            try file.writeAll(line);
+        }
+        if (self.artifact_sha256) |sha| {
+            const line = try std.fmt.allocPrint(allocator, "artifact_sha256={s}\n", .{sha[0..]});
+            defer allocator.free(line);
+            try file.writeAll(line);
+        }
+        if (self.signature) |sig| {
+            const line = try std.fmt.allocPrint(allocator, "signature=ed25519:{s}\n", .{sig[0..]});
+            defer allocator.free(line);
+            try file.writeAll(line);
+        }
+        if (self.signing_pubkey) |pk| {
+            const line = try std.fmt.allocPrint(allocator, "signing_pubkey={s}\n", .{pk[0..]});
+            defer allocator.free(line);
+            try file.writeAll(line);
+        }
+        if (self.wasm_path) |wp| {
+            const line = try std.fmt.allocPrint(allocator, "wasm_path={s}\n", .{wp});
+            defer allocator.free(line);
+            try file.writeAll(line);
+        }
+        if (self.wasm_digest) |wd| {
+            const line = try std.fmt.allocPrint(allocator, "wasm_digest={s}\n", .{wd[0..]});
+            defer allocator.free(line);
+            try file.writeAll(line);
+        }
+        if (self.tool_version) |tv| {
+            const line = try std.fmt.allocPrint(allocator, "tool_version={s}\n", .{tv});
+            defer allocator.free(line);
+            try file.writeAll(line);
+        }
+        if (self.artifact_inline_b64) |b64| {
+            const line = try std.fmt.allocPrint(allocator, "artifact_inline_b64={s}\n", .{b64});
+            defer allocator.free(line);
+            try file.writeAll(line);
+        }
     }
 
     /// Thaw a frozen Baton. All string fields are heap-owned — call `deinit`.
@@ -136,30 +292,67 @@ pub const CheckBaton = struct {
         var lines = std.mem.splitScalar(u8, content, '\n');
         while (lines.next()) |line| {
             const eq = std.mem.indexOfScalar(u8, line, '=') orelse continue;
-            const key = line[0..eq];
+            const k = line[0..eq];
             const val = line[eq + 1 ..];
-            if (std.mem.eql(u8, key, "id")) {
+            if (std.mem.eql(u8, k, "id")) {
                 allocator.free(b.id);
                 b.id = try allocator.dupe(u8, val);
-            } else if (std.mem.eql(u8, key, "check_id")) {
+            } else if (std.mem.eql(u8, k, "check_id")) {
                 allocator.free(b.check_id);
                 b.check_id = try allocator.dupe(u8, val);
-            } else if (std.mem.eql(u8, key, "node")) {
+            } else if (std.mem.eql(u8, k, "node")) {
                 allocator.free(b.node);
                 b.node = try allocator.dupe(u8, val);
-            } else if (std.mem.eql(u8, key, "required_cap")) {
+            } else if (std.mem.eql(u8, k, "required_cap")) {
                 b.required_cap = estate.Capability.fromString(val) orelse .linux;
-            } else if (std.mem.eql(u8, key, "verdict")) {
+            } else if (std.mem.eql(u8, k, "verdict")) {
                 b.verdict = Verdict.fromString(val) orelse .pending;
-            } else if (std.mem.eql(u8, key, "exit_code")) {
+            } else if (std.mem.eql(u8, k, "exit_code")) {
                 b.exit_code = std.fmt.parseInt(i32, val, 10) catch 0;
-            } else if (std.mem.eql(u8, key, "command")) {
+            } else if (std.mem.eql(u8, k, "command")) {
                 allocator.free(b.command);
                 b.command = try allocator.dupe(u8, val);
-            } else if (std.mem.eql(u8, key, "digest")) {
+            } else if (std.mem.eql(u8, k, "digest")) {
                 const hex = if (std.mem.startsWith(u8, val, "hmac-sha256:")) val["hmac-sha256:".len..] else val;
                 const n = @min(hex.len, 64);
                 @memcpy(b.digest[0..n], hex[0..n]);
+            } else if (std.mem.eql(u8, k, "artifact_path")) {
+                if (b.artifact_path) |old| allocator.free(old);
+                b.artifact_path = try allocator.dupe(u8, val);
+            } else if (std.mem.eql(u8, k, "artifact_sha256")) {
+                var sha: [64]u8 = undefined;
+                const n = @min(val.len, 64);
+                @memcpy(sha[0..n], val[0..n]);
+                if (n < 64) @memset(sha[n..], '0');
+                b.artifact_sha256 = sha;
+            } else if (std.mem.eql(u8, k, "signature")) {
+                const hex = if (std.mem.startsWith(u8, val, "ed25519:")) val["ed25519:".len..] else val;
+                if (hex.len == 128) {
+                    var sig: [128]u8 = undefined;
+                    @memcpy(&sig, hex[0..128]);
+                    b.signature = sig;
+                }
+            } else if (std.mem.eql(u8, k, "signing_pubkey")) {
+                if (val.len == 64) {
+                    var pk: [64]u8 = undefined;
+                    @memcpy(&pk, val[0..64]);
+                    b.signing_pubkey = pk;
+                }
+            } else if (std.mem.eql(u8, k, "wasm_path")) {
+                if (b.wasm_path) |old| allocator.free(old);
+                b.wasm_path = try allocator.dupe(u8, val);
+            } else if (std.mem.eql(u8, k, "wasm_digest")) {
+                if (val.len == 64) {
+                    var wd: [64]u8 = undefined;
+                    @memcpy(&wd, val[0..64]);
+                    b.wasm_digest = wd;
+                }
+            } else if (std.mem.eql(u8, k, "tool_version")) {
+                if (b.tool_version) |old| allocator.free(old);
+                b.tool_version = try allocator.dupe(u8, val);
+            } else if (std.mem.eql(u8, k, "artifact_inline_b64")) {
+                if (b.artifact_inline_b64) |old| allocator.free(old);
+                b.artifact_inline_b64 = try allocator.dupe(u8, val);
             }
         }
         return b;
@@ -170,11 +363,182 @@ pub const CheckBaton = struct {
         allocator.free(self.check_id);
         allocator.free(self.node);
         allocator.free(self.command);
+        if (self.artifact_path) |ap| allocator.free(ap);
+        if (self.wasm_path) |wp| allocator.free(wp);
+        if (self.tool_version) |tv| allocator.free(tv);
+        if (self.artifact_inline_b64) |b64| allocator.free(b64);
     }
 };
 
-/// The shared key used to attest frozen verdicts. Reads BAG_ATTEST_KEY; falls
-/// back to a documented dev placeholder (integrity-only until a real key is set).
+/// Hex-decode `hex` into `dst`; `dst.len * 2 == hex.len` must hold.
+fn hexDecode(dst: []u8, hex: []const u8) !void {
+    if (hex.len != dst.len * 2) return error.InvalidHexLength;
+    for (0..dst.len) |i| {
+        const hi = std.fmt.charToDigit(hex[i * 2], 16) catch return error.InvalidHex;
+        const lo = std.fmt.charToDigit(hex[i * 2 + 1], 16) catch return error.InvalidHex;
+        dst[i] = @as(u8, @intCast(hi)) << 4 | @as(u8, @intCast(lo));
+    }
+}
+
+/// Parse an unencrypted OpenSSH ed25519 private key file and return the 32-byte seed.
+/// Encrypted keys (cipher != "none") are rejected with EncryptedKeyNotSupported.
+fn readEd25519Seed(allocator: std.mem.Allocator, path: []const u8) ![32]u8 {
+    const file = try std.fs.cwd().openFile(path, .{});
+    defer file.close();
+    const pem = try file.readToEndAlloc(allocator, 8192);
+    defer allocator.free(pem);
+
+    // Strip PEM header/footer and concatenate base64 payload lines.
+    var b64: std.ArrayList(u8) = .empty;
+    defer b64.deinit(allocator);
+    var iter = std.mem.splitScalar(u8, pem, '\n');
+    while (iter.next()) |line| {
+        const t = std.mem.trim(u8, line, " \r\t");
+        if (t.len == 0 or std.mem.startsWith(u8, t, "-----")) continue;
+        try b64.appendSlice(allocator, t);
+    }
+
+    const decoded_len = std.base64.standard.Decoder.calcSizeForSlice(b64.items) catch return error.InvalidKeyFormat;
+    const decoded = try allocator.alloc(u8, decoded_len);
+    defer allocator.free(decoded);
+    try std.base64.standard.Decoder.decode(decoded, b64.items);
+
+    // Validate OpenSSH magic.
+    const magic = "openssh-key-v1\x00";
+    if (decoded.len < magic.len or !std.mem.startsWith(u8, decoded, magic)) return error.NotOpenSSHKey;
+    var pos: usize = magic.len;
+
+    // cipher name — must be "none" (unencrypted).
+    if (pos + 4 > decoded.len) return error.InvalidKeyFormat;
+    const cipher_len = std.mem.readInt(u32, decoded[pos..][0..4], .big);
+    pos += 4;
+    if (pos + cipher_len > decoded.len) return error.InvalidKeyFormat;
+    if (!std.mem.eql(u8, decoded[pos .. pos + cipher_len], "none")) return error.EncryptedKeyNotSupported;
+    pos += cipher_len;
+
+    // kdf name (skip).
+    if (pos + 4 > decoded.len) return error.InvalidKeyFormat;
+    const kdf_len = std.mem.readInt(u32, decoded[pos..][0..4], .big);
+    pos += 4;
+    if (pos + kdf_len > decoded.len) return error.InvalidKeyFormat;
+    pos += kdf_len;
+
+    // kdf options (skip).
+    if (pos + 4 > decoded.len) return error.InvalidKeyFormat;
+    const kdf_opts_len = std.mem.readInt(u32, decoded[pos..][0..4], .big);
+    pos += 4;
+    if (pos + kdf_opts_len > decoded.len) return error.InvalidKeyFormat;
+    pos += kdf_opts_len;
+
+    // nkeys (skip).
+    if (pos + 4 > decoded.len) return error.InvalidKeyFormat;
+    pos += 4;
+
+    // public key blob (skip).
+    if (pos + 4 > decoded.len) return error.InvalidKeyFormat;
+    const pub_blob_len = std.mem.readInt(u32, decoded[pos..][0..4], .big);
+    pos += 4;
+    if (pos + pub_blob_len > decoded.len) return error.InvalidKeyFormat;
+    pos += pub_blob_len;
+
+    // private key blob length (skip — we parse the blob inline below).
+    if (pos + 4 > decoded.len) return error.InvalidKeyFormat;
+    pos += 4;
+
+    // check1 == check2 (corruption guard).
+    if (pos + 8 > decoded.len) return error.InvalidKeyFormat;
+    if (!std.mem.eql(u8, decoded[pos .. pos + 4], decoded[pos + 4 .. pos + 8])) return error.KeyCorrupted;
+    pos += 8;
+
+    // key type.
+    if (pos + 4 > decoded.len) return error.InvalidKeyFormat;
+    const kt_len = std.mem.readInt(u32, decoded[pos..][0..4], .big);
+    pos += 4;
+    if (pos + kt_len > decoded.len) return error.InvalidKeyFormat;
+    if (!std.mem.eql(u8, decoded[pos .. pos + kt_len], "ssh-ed25519")) return error.NotEd25519Key;
+    pos += kt_len;
+
+    // inner public key (skip).
+    if (pos + 4 > decoded.len) return error.InvalidKeyFormat;
+    const inner_pub_len = std.mem.readInt(u32, decoded[pos..][0..4], .big);
+    pos += 4;
+    if (pos + inner_pub_len > decoded.len) return error.InvalidKeyFormat;
+    pos += inner_pub_len;
+
+    // seed+pubkey field: 4-byte length (must be 64) + 32-byte seed + 32-byte pubkey.
+    if (pos + 4 > decoded.len) return error.InvalidKeyFormat;
+    const sp_len = std.mem.readInt(u32, decoded[pos..][0..4], .big);
+    pos += 4;
+    if (sp_len != 64 or pos + 32 > decoded.len) return error.InvalidKeyFormat;
+
+    var seed: [32]u8 = undefined;
+    @memcpy(&seed, decoded[pos..][0..32]);
+    return seed;
+}
+
+/// Parse an SSH ed25519 public key file (.pub) and return the 32-byte raw key.
+fn readEd25519Pubkey(allocator: std.mem.Allocator, path: []const u8) ![32]u8 {
+    const file = try std.fs.cwd().openFile(path, .{});
+    defer file.close();
+    const content = try file.readToEndAlloc(allocator, 4096);
+    defer allocator.free(content);
+
+    // Format: "ssh-ed25519 <base64-blob> [comment]"
+    const trimmed = std.mem.trim(u8, content, " \r\n\t");
+    var parts = std.mem.splitScalar(u8, trimmed, ' ');
+    const keytype = parts.next() orelse return error.InvalidPubkeyFormat;
+    if (!std.mem.eql(u8, keytype, "ssh-ed25519")) return error.NotEd25519Pubkey;
+    const b64 = parts.next() orelse return error.InvalidPubkeyFormat;
+
+    const decoded_len = std.base64.standard.Decoder.calcSizeForSlice(b64) catch return error.InvalidPubkeyFormat;
+    const decoded = try allocator.alloc(u8, decoded_len);
+    defer allocator.free(decoded);
+    try std.base64.standard.Decoder.decode(decoded, b64);
+
+    // blob: 4-byte type-len + "ssh-ed25519" + 4-byte key-len (32) + 32-byte key.
+    var pos: usize = 0;
+    if (pos + 4 > decoded.len) return error.InvalidPubkeyFormat;
+    const type_len = std.mem.readInt(u32, decoded[pos..][0..4], .big);
+    pos += 4;
+    if (pos + type_len > decoded.len) return error.InvalidPubkeyFormat;
+    pos += type_len; // skip "ssh-ed25519"
+    if (pos + 4 > decoded.len) return error.InvalidPubkeyFormat;
+    const key_len = std.mem.readInt(u32, decoded[pos..][0..4], .big);
+    pos += 4;
+    if (key_len != 32 or pos + 32 > decoded.len) return error.InvalidPubkeyFormat;
+
+    var pubkey: [32]u8 = undefined;
+    @memcpy(&pubkey, decoded[pos..][0..32]);
+    return pubkey;
+}
+
+/// Compute a hex-encoded SHA-256 digest of the file at `path` using streaming
+/// reads so arbitrarily large report files (SARIF, SBOM, Scorecard JSON) do not
+/// need to fit in memory. Returns 64 hex chars in a `[64]u8`.
+fn hashFile(path: []const u8) ![64]u8 {
+    const file = try std.fs.cwd().openFile(path, .{});
+    defer file.close();
+    const Sha256 = std.crypto.hash.sha2.Sha256;
+    var hasher = Sha256.init(.{});
+    var buf: [8192]u8 = undefined;
+    while (true) {
+        const n = try file.read(&buf);
+        if (n == 0) break;
+        hasher.update(buf[0..n]);
+    }
+    var hash: [Sha256.digest_length]u8 = undefined;
+    hasher.final(&hash);
+    const hexchars = "0123456789abcdef";
+    var hex: [64]u8 = undefined;
+    for (hash, 0..) |byte, i| {
+        hex[i * 2] = hexchars[byte >> 4];
+        hex[i * 2 + 1] = hexchars[byte & 0x0f];
+    }
+    return hex;
+}
+
+/// The shared key used for HMAC attestation. Reads BAG_ATTEST_KEY; falls back
+/// to a documented dev placeholder (integrity-only until a real key is set).
 fn attestKey(allocator: std.mem.Allocator) ![]const u8 {
     return std.process.getEnvVarOwned(allocator, "BAG_ATTEST_KEY") catch
         try allocator.dupe(u8, "bag-of-actions-dev-key");
@@ -292,10 +656,34 @@ pub fn main() !void {
             std.process.exit(2);
         }
 
-        // 2. Execute the real check on this (capable) node.
+        // 2. Detect WASI mode: wasm://<path> prefix switches to wasmtime execution.
+        //    The module is hashed so the exact Wasm binary is bound to the verdict.
+        const wasm_module_path: ?[]const u8 = if (cmd_argv.len > 0 and
+            std.mem.startsWith(u8, cmd_argv[0], "wasm://"))
+            cmd_argv[0]["wasm://".len..]
+        else
+            null;
+        const wasm_digest_opt: ?[64]u8 = if (wasm_module_path) |wmp|
+            hashFile(wmp) catch null
+        else
+            null;
+
+        // Build exec argv: wasmtime run --dir=. <module> [rest...] or the original argv.
+        var wasm_argv_buf: [32][]const u8 = undefined;
+        const exec_argv: []const []const u8 = if (wasm_module_path) |wmp| blk: {
+            wasm_argv_buf[0] = "wasmtime";
+            wasm_argv_buf[1] = "run";
+            wasm_argv_buf[2] = "--dir=.";
+            wasm_argv_buf[3] = wmp;
+            const extra = cmd_argv.len - 1;
+            if (extra > 0) @memcpy(wasm_argv_buf[4 .. 4 + extra], cmd_argv[1..]);
+            break :blk wasm_argv_buf[0 .. 4 + extra];
+        } else cmd_argv;
+
+        // 3. Execute the real check on this (capable) node.
         const result = try std.process.Child.run(.{
             .allocator = allocator,
-            .argv = cmd_argv,
+            .argv = exec_argv,
         });
         defer allocator.free(result.stdout);
         defer allocator.free(result.stderr);
@@ -306,13 +694,79 @@ pub fn main() !void {
         };
         const verdict: Verdict = if (code == 0) .pass else .fail;
 
-        // 3. Freeze the verdict — the portable artifact that replaces a paid run.
+        // 4. Hash the artifact report if BAG_ARTIFACT_PATH is set (generic: works
+        //    for any check that writes a file — Scorecard JSON, SARIF, SBOM, etc.).
+        const artifact_path_env = std.process.getEnvVarOwned(allocator, "BAG_ARTIFACT_PATH") catch null;
+        defer if (artifact_path_env) |p| allocator.free(p);
+        const artifact_sha256_opt: ?[64]u8 = if (artifact_path_env) |ap|
+            hashFile(ap) catch null
+        else
+            null;
+
+        // 5. Read optional v2 metadata: tool version + inline artifact (≤ BAG_ARTIFACT_INLINE_MAX bytes).
+        const tool_version_opt = std.process.getEnvVarOwned(allocator, "BAG_TOOL_VERSION") catch null;
+        defer if (tool_version_opt) |tv| allocator.free(tv);
+
+        const inline_max: usize = blk: {
+            const v = std.process.getEnvVarOwned(allocator, "BAG_ARTIFACT_INLINE_MAX") catch null;
+            defer if (v) |s| allocator.free(s);
+            break :blk if (v) |s| std.fmt.parseInt(usize, s, 10) catch 4096 else 4096;
+        };
+        const artifact_inline_b64_opt: ?[]u8 = if (artifact_path_env) |ap| blk: {
+            const raw = std.fs.cwd().readFileAlloc(allocator, ap, inline_max) catch break :blk null;
+            defer allocator.free(raw);
+            const b64_len = std.base64.standard.Encoder.calcSize(raw.len);
+            const b64_buf = try allocator.alloc(u8, b64_len);
+            _ = std.base64.standard.Encoder.encode(b64_buf, raw);
+            break :blk b64_buf;
+        } else null;
+        defer if (artifact_inline_b64_opt) |b| allocator.free(b);
+
+        // 6. Build the Baton with the executed verdict and all metadata.
         const joined = try std.mem.join(allocator, " ", cmd_argv);
         defer allocator.free(joined);
-        const baton = CheckBaton{ .id = check_id, .check_id = check_id, .node = node, .required_cap = cap, .verdict = verdict, .exit_code = code, .command = joined };
+        var baton = CheckBaton{
+            .id = check_id,
+            .check_id = check_id,
+            .node = node,
+            .required_cap = cap,
+            .verdict = verdict,
+            .exit_code = code,
+            .command = joined,
+            .artifact_path = artifact_path_env,
+            .artifact_sha256 = artifact_sha256_opt,
+            .wasm_path = wasm_module_path,
+            .wasm_digest = wasm_digest_opt,
+            .tool_version = tool_version_opt,
+            .artifact_inline_b64 = artifact_inline_b64_opt,
+        };
+
+        // 7. Attempt ed25519 signing for authenticity-evident attestation.
+        //    Fail-open: if the key is absent or unreadable the Baton is still
+        //    HMAC-attested. Use BAG_SIGN_KEY_PATH or ~/.ssh/id_ed25519_signing
+        //    (the estate signing key; id_ed25519 is auth-only and must NOT be used).
+        const sign_key_path: ?[]u8 = blk: {
+            if (std.process.getEnvVarOwned(allocator, "BAG_SIGN_KEY_PATH")) |p| break :blk p else |_| {}
+            const home = std.process.getEnvVarOwned(allocator, "HOME") catch break :blk null;
+            defer allocator.free(home);
+            break :blk std.fmt.allocPrint(allocator, "{s}/.ssh/id_ed25519_signing", .{home}) catch null;
+        };
+        defer if (sign_key_path) |p| allocator.free(p);
+
+        if (sign_key_path) |skp| {
+            if (baton.signEd25519(allocator, skp)) |ed_result| {
+                baton.signature = ed_result.sig;
+                baton.signing_pubkey = ed_result.pubkey;
+            } else |_| {} // key absent / unreadable → HMAC-only, not an error
+        }
+
+        // 8. Freeze (HMAC + ed25519 signature if signing succeeded).
         try baton.freeze(allocator, freeze_path, key);
 
-        try printOut(allocator, "VERDICT={s}\ncheck_id={s} node={s} cap={s} exit_code={d}\nFrozen+attested to {s} (0 GitHub minutes)\n", .{ @tagName(verdict), check_id, node, @tagName(cap), code, freeze_path });
+        const has_artifact = if (artifact_sha256_opt != null) "yes" else "no";
+        const has_sig = if (baton.signature != null) "yes" else "no";
+        const has_wasm = if (wasm_module_path != null) "yes" else "no";
+        try printOut(allocator, "VERDICT={s}\ncheck_id={s} node={s} cap={s} exit_code={d} artifact={s} wasm={s} ed25519={s}\nFrozen+attested to {s} (0 GitHub minutes)\n", .{ @tagName(verdict), check_id, node, @tagName(cap), code, has_artifact, has_wasm, has_sig, freeze_path });
         std.process.exit(if (verdict == .pass) 0 else 1);
     } else if (std.mem.eql(u8, args[1], "thaw")) {
         // bag_of_actions thaw <freeze_path>
@@ -326,12 +780,22 @@ pub fn main() !void {
 
         const key = try attestKey(allocator);
         defer allocator.free(key);
-        if (!try baton.verify(allocator, key)) {
-            try printOut(allocator, "VERDICT=tampered\ncheck_id={s}: attestation digest does not match — verdict REJECTED.\n", .{baton.check_id});
+
+        // Verify both attestation layers; reject if either fails.
+        const hmac_ok = try baton.verify(allocator, key);
+        const ed25519_ok = try baton.verifyEd25519(allocator);
+        const has_sig = baton.signature != null;
+        const ed25519_status: []const u8 = if (!has_sig) "none" else if (ed25519_ok) "verified" else "FAILED";
+
+        if (!hmac_ok or (has_sig and !ed25519_ok)) {
+            const reason: []const u8 = if (!hmac_ok) "hmac" else "ed25519";
+            try printOut(allocator, "VERDICT=tampered\ncheck_id={s}: attestation failed ({s}) — verdict REJECTED.\n", .{ baton.check_id, reason });
             std.process.exit(3);
         }
 
-        try printOut(allocator, "VERDICT={s}\ncheck_id={s} node={s} cap={s} exit_code={d}\ncommand={s}\nattestation=verified\n", .{ @tagName(baton.verdict), baton.check_id, baton.node, @tagName(baton.required_cap), baton.exit_code, baton.command });
+        try printOut(allocator, "VERDICT={s}\ncheck_id={s} node={s} cap={s} exit_code={d}\ncommand={s}\nattestation=hmac:verified ed25519:{s}\n", .{ @tagName(baton.verdict), baton.check_id, baton.node, @tagName(baton.required_cap), baton.exit_code, baton.command, ed25519_status });
+        if (baton.tool_version) |tv| try printOut(allocator, "tool_version={s}\n", .{tv});
+        if (baton.wasm_path) |wp| try printOut(allocator, "wasm_path={s}\n", .{wp});
         std.process.exit(if (baton.verdict == .pass) 0 else 1);
     } else if (std.mem.eql(u8, args[1], "run")) {
         var baton = try Baton.load(allocator, "baton.txt");
@@ -375,6 +839,8 @@ pub fn main() !void {
         std.debug.print("Baton cycle complete. Saved for next node.\n", .{});
     }
 }
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
 
 test "CheckBaton freeze/thaw round-trips the verdict and verifies attestation" {
     const a = std.testing.allocator;
@@ -490,4 +956,354 @@ test "Verdict.fromString parses known tags and rejects unknown" {
     try std.testing.expect(Verdict.fromString("fail").? == .fail);
     try std.testing.expect(Verdict.fromString("pending").? == .pending);
     try std.testing.expect(Verdict.fromString("bogus") == null);
+}
+
+test "Capability.fromString recognises scorecard (tag 11)" {
+    const cap = estate.Capability.fromString("scorecard");
+    try std.testing.expect(cap != null);
+    try std.testing.expect(cap.? == .scorecard);
+    try std.testing.expect(@intFromEnum(cap.?) == 11);
+}
+
+test "Capability.fromString rejects unknown capabilities (fail closed)" {
+    try std.testing.expect(estate.Capability.fromString("bogus-unknown-cap") == null);
+    try std.testing.expect(estate.Capability.fromString("") == null);
+    try std.testing.expect(estate.Capability.fromString("SCORECARD") == null); // case-sensitive
+}
+
+test "CheckBaton with artifact_sha256 round-trips and verifies attestation" {
+    const a = std.testing.allocator;
+    const key = "test-key";
+    var sha: [64]u8 = undefined;
+    @memset(&sha, 'a'); // deterministic dummy hex value for test
+    const original = CheckBaton{
+        .id = "cib-art-001",
+        .check_id = "ossf-scorecard",
+        .node = "mesh-server-1",
+        .required_cap = .scorecard,
+        .verdict = .pass,
+        .exit_code = 0,
+        .command = "./scripts/baton-scorecard.sh",
+        .artifact_path = "_bag_artifacts/scorecard/scorecard.json",
+        .artifact_sha256 = sha,
+    };
+    const path = "test-ci-baton-artifact-rt.txt";
+    try original.freeze(a, path, key);
+    defer std.fs.cwd().deleteFile(path) catch {};
+
+    var thawed = try CheckBaton.thaw(a, path);
+    defer thawed.deinit(a);
+
+    try std.testing.expect(thawed.artifact_sha256 != null);
+    try std.testing.expectEqualSlices(u8, sha[0..], thawed.artifact_sha256.?[0..]);
+    try std.testing.expectEqualStrings("_bag_artifacts/scorecard/scorecard.json", thawed.artifact_path.?);
+    try std.testing.expect(try thawed.verify(a, key));
+}
+
+test "tampering with artifact_sha256 is detected on thaw" {
+    const a = std.testing.allocator;
+    const key = "test-key";
+    var sha: [64]u8 = undefined;
+    @memset(&sha, 'b');
+    const original = CheckBaton{
+        .id = "cib-art-002",
+        .check_id = "ossf-scorecard",
+        .node = "mesh-server-1",
+        .required_cap = .scorecard,
+        .verdict = .pass,
+        .exit_code = 0,
+        .command = "./scripts/baton-scorecard.sh",
+        .artifact_sha256 = sha,
+    };
+    const path = "test-ci-baton-artifact-tamper.txt";
+    try original.freeze(a, path, key);
+    defer std.fs.cwd().deleteFile(path) catch {};
+
+    // Replace the artifact_sha256 line in the frozen envelope.
+    const content = blk: {
+        const rf = try std.fs.cwd().openFile(path, .{});
+        defer rf.close();
+        break :blk try rf.readToEndAlloc(a, 8192);
+    };
+    defer a.free(content);
+    const prefix = "artifact_sha256=";
+    var old_line: [prefix.len + 64]u8 = undefined;
+    @memcpy(old_line[0..prefix.len], prefix);
+    @memset(old_line[prefix.len..], 'b');
+    var new_line: [prefix.len + 64]u8 = undefined;
+    @memcpy(new_line[0..prefix.len], prefix);
+    @memset(new_line[prefix.len..], 'c');
+    const forged = try std.mem.replaceOwned(u8, a, content, &old_line, &new_line);
+    defer a.free(forged);
+    {
+        const f = try std.fs.cwd().createFile(path, .{});
+        defer f.close();
+        try f.writeAll(forged);
+    }
+
+    var thawed = try CheckBaton.thaw(a, path);
+    defer thawed.deinit(a);
+    try std.testing.expect(!try thawed.verify(a, key)); // tampered artifact sha → rejected
+}
+
+test "old envelope without artifact fields still verifies (backward compat)" {
+    const a = std.testing.allocator;
+    const key = "test-key";
+    // No artifact_sha256 — uses the pre-artifact canonical string format.
+    const original = CheckBaton{
+        .id = "cib-compat-001",
+        .check_id = "zig-fmt",
+        .node = "mesh-server-1",
+        .required_cap = .zig,
+        .verdict = .pass,
+        .exit_code = 0,
+        .command = "zig fmt --check build.zig",
+    };
+    const path = "test-ci-baton-compat.txt";
+    try original.freeze(a, path, key);
+    defer std.fs.cwd().deleteFile(path) catch {};
+
+    var thawed = try CheckBaton.thaw(a, path);
+    defer thawed.deinit(a);
+
+    try std.testing.expect(thawed.artifact_sha256 == null);
+    try std.testing.expect(thawed.artifact_path == null);
+    try std.testing.expect(try thawed.verify(a, key));
+}
+
+test "ed25519 sign/verify round-trip using synthetic key" {
+    const a = std.testing.allocator;
+    const seed = [_]u8{0x42} ** 32; // deterministic test seed
+    var baton = CheckBaton{
+        .id = "cib-ed25519-001",
+        .check_id = "zig-fmt",
+        .node = "mesh-server-1",
+        .required_cap = .zig,
+        .verdict = .pass,
+        .exit_code = 0,
+        .command = "zig fmt --check build.zig",
+    };
+    const ed_result = try baton.signEd25519WithSeed(a, seed);
+    baton.signature = ed_result.sig;
+    baton.signing_pubkey = ed_result.pubkey;
+    try std.testing.expect(try baton.verifyEd25519(a));
+}
+
+test "ed25519 tampered verdict is rejected" {
+    const a = std.testing.allocator;
+    const seed = [_]u8{0x42} ** 32;
+    const original = CheckBaton{
+        .id = "cib-ed25519-002",
+        .check_id = "zig-fmt",
+        .node = "mesh-server-1",
+        .required_cap = .zig,
+        .verdict = .pass,
+        .exit_code = 0,
+        .command = "zig fmt --check build.zig",
+    };
+    const ed_result = try original.signEd25519WithSeed(a, seed);
+    // Signature was computed over .pass verdict; .fail should not verify.
+    var tampered = original;
+    tampered.verdict = .fail;
+    tampered.signature = ed_result.sig;
+    tampered.signing_pubkey = ed_result.pubkey;
+    try std.testing.expect(!try tampered.verifyEd25519(a));
+}
+
+test "ed25519 signature survives freeze/thaw cycle" {
+    const a = std.testing.allocator;
+    const seed = [_]u8{0x43} ** 32;
+    var original = CheckBaton{
+        .id = "cib-ed25519-003",
+        .check_id = "zig-fmt",
+        .node = "mesh-server-1",
+        .required_cap = .zig,
+        .verdict = .pass,
+        .exit_code = 0,
+        .command = "zig fmt --check build.zig",
+    };
+    const ed_result = try original.signEd25519WithSeed(a, seed);
+    original.signature = ed_result.sig;
+    original.signing_pubkey = ed_result.pubkey;
+
+    const path = "test-ci-baton-ed25519-rt.txt";
+    try original.freeze(a, path, "test-key");
+    defer std.fs.cwd().deleteFile(path) catch {};
+
+    var thawed = try CheckBaton.thaw(a, path);
+    defer thawed.deinit(a);
+
+    try std.testing.expect(thawed.signature != null);
+    try std.testing.expect(thawed.signing_pubkey != null);
+    try std.testing.expect(try thawed.verifyEd25519(a));
+    try std.testing.expect(try thawed.verify(a, "test-key")); // HMAC still works too
+}
+
+test "baton without ed25519 signature returns false from verifyEd25519 (not an error)" {
+    const a = std.testing.allocator;
+    const baton = CheckBaton{
+        .id = "cib-ed25519-004",
+        .check_id = "zig-fmt",
+        .node = "mesh-server-1",
+        .required_cap = .zig,
+        .verdict = .pass,
+        .exit_code = 0,
+        .command = "zig fmt --check build.zig",
+    };
+    // No signature present → false, not an error.
+    try std.testing.expect(!try baton.verifyEd25519(a));
+}
+
+test "hexDecode round-trips known hex strings" {
+    var buf: [4]u8 = undefined;
+    try hexDecode(&buf, "deadbeef");
+    try std.testing.expectEqualSlices(u8, &[_]u8{ 0xde, 0xad, 0xbe, 0xef }, &buf);
+}
+
+test "hexDecode rejects invalid hex chars" {
+    var buf: [2]u8 = undefined;
+    try std.testing.expectError(error.InvalidHex, hexDecode(&buf, "zz00"));
+}
+
+test "Capability.fromString recognises wasm (tag 12)" {
+    const cap = estate.Capability.fromString("wasm");
+    try std.testing.expect(cap != null);
+    try std.testing.expect(cap.? == .wasm);
+    try std.testing.expect(@intFromEnum(cap.?) == 12);
+}
+
+test "wasm_digest extends canonical string and changes HMAC" {
+    const a = std.testing.allocator;
+    const key = "test-key";
+    var sha: [64]u8 = undefined;
+    @memset(&sha, 'w');
+    const with_wasm = CheckBaton{
+        .id = "cib-wasm-001",
+        .check_id = "zig-fmt-wasm",
+        .node = "mesh-server-1",
+        .required_cap = .wasm,
+        .verdict = .pass,
+        .exit_code = 0,
+        .command = "wasm://zig-out/lib/zig_fmt.wasm src/main.zig",
+        .wasm_digest = sha,
+    };
+    const without_wasm = CheckBaton{
+        .id = "cib-wasm-001",
+        .check_id = "zig-fmt-wasm",
+        .node = "mesh-server-1",
+        .required_cap = .wasm,
+        .verdict = .pass,
+        .exit_code = 0,
+        .command = "wasm://zig-out/lib/zig_fmt.wasm src/main.zig",
+    };
+    const h1 = try with_wasm.digestHex(a, key);
+    const h2 = try without_wasm.digestHex(a, key);
+    try std.testing.expect(!std.mem.eql(u8, h1[0..], h2[0..]));
+}
+
+test "tool_version extends canonical string and changes HMAC" {
+    const a = std.testing.allocator;
+    const key = "test-key";
+    const with_ver = CheckBaton{
+        .id = "cib-tv-001",
+        .check_id = "scorecard",
+        .node = "mesh-server-1",
+        .required_cap = .scorecard,
+        .verdict = .pass,
+        .exit_code = 0,
+        .command = "./scripts/baton-scorecard.sh",
+        .tool_version = "scorecard 5.1.0",
+    };
+    const without_ver = CheckBaton{
+        .id = "cib-tv-001",
+        .check_id = "scorecard",
+        .node = "mesh-server-1",
+        .required_cap = .scorecard,
+        .verdict = .pass,
+        .exit_code = 0,
+        .command = "./scripts/baton-scorecard.sh",
+    };
+    const h1 = try with_ver.digestHex(a, key);
+    const h2 = try without_ver.digestHex(a, key);
+    try std.testing.expect(!std.mem.eql(u8, h1[0..], h2[0..]));
+}
+
+test "wasm_digest + tool_version round-trip freeze/thaw with attestation" {
+    const a = std.testing.allocator;
+    const key = "test-key";
+    var wd: [64]u8 = undefined;
+    @memset(&wd, 'f');
+    const original = CheckBaton{
+        .id = "cib-v2-001",
+        .check_id = "zig-fmt-wasm",
+        .node = "mesh-server-1",
+        .required_cap = .wasm,
+        .verdict = .pass,
+        .exit_code = 0,
+        .command = "wasm://zig-out/lib/zig_fmt.wasm src/main.zig",
+        .wasm_digest = wd,
+        .tool_version = "zig 0.15.2",
+    };
+    const path = "test-ci-baton-v2-rt.txt";
+    try original.freeze(a, path, key);
+    defer std.fs.cwd().deleteFile(path) catch {};
+
+    var thawed = try CheckBaton.thaw(a, path);
+    defer thawed.deinit(a);
+
+    try std.testing.expect(thawed.wasm_digest != null);
+    try std.testing.expectEqualSlices(u8, wd[0..], thawed.wasm_digest.?[0..]);
+    try std.testing.expect(thawed.tool_version != null);
+    try std.testing.expectEqualStrings("zig 0.15.2", thawed.tool_version.?);
+    try std.testing.expect(try thawed.verify(a, key));
+}
+
+test "artifact_inline_b64 round-trips freeze/thaw" {
+    const a = std.testing.allocator;
+    const key = "test-key";
+    const original = CheckBaton{
+        .id = "cib-b64-001",
+        .check_id = "scorecard",
+        .node = "mesh-server-1",
+        .required_cap = .scorecard,
+        .verdict = .pass,
+        .exit_code = 0,
+        .command = "./scripts/baton-scorecard.sh",
+        .artifact_inline_b64 = "eyJzY29yZSI6OX0=",
+    };
+    const path = "test-ci-baton-b64-rt.txt";
+    try original.freeze(a, path, key);
+    defer std.fs.cwd().deleteFile(path) catch {};
+
+    var thawed = try CheckBaton.thaw(a, path);
+    defer thawed.deinit(a);
+
+    try std.testing.expect(thawed.artifact_inline_b64 != null);
+    try std.testing.expectEqualStrings("eyJzY29yZSI6OX0=", thawed.artifact_inline_b64.?);
+    try std.testing.expect(try thawed.verify(a, key));
+}
+
+test "old envelope without v2 fields still verifies (backward compat)" {
+    const a = std.testing.allocator;
+    const key = "test-key";
+    const original = CheckBaton{
+        .id = "cib-v2-compat-001",
+        .check_id = "zig-fmt",
+        .node = "mesh-server-1",
+        .required_cap = .zig,
+        .verdict = .pass,
+        .exit_code = 0,
+        .command = "zig fmt --check build.zig",
+    };
+    const path = "test-ci-baton-v2-compat.txt";
+    try original.freeze(a, path, key);
+    defer std.fs.cwd().deleteFile(path) catch {};
+
+    var thawed = try CheckBaton.thaw(a, path);
+    defer thawed.deinit(a);
+
+    try std.testing.expect(thawed.wasm_digest == null);
+    try std.testing.expect(thawed.tool_version == null);
+    try std.testing.expect(thawed.artifact_inline_b64 == null);
+    try std.testing.expect(try thawed.verify(a, key));
 }

--- a/verification/proofs/Bag/Estate.idr
+++ b/verification/proofs/Bag/Estate.idr
@@ -26,7 +26,7 @@ public export
 estate : List Node
 estate =
   [ MkNode "mesh-laptop"        [MacOS, Guix, TrustedHost "Jonathan", Zig] 2
-  , MkNode "mesh-server-1"      [Linux, GPU, Guix, TrustedHost "Core-Infrastructure", Zig, Rust, Cargo, Deno] 1
+  , MkNode "mesh-server-1"      [Linux, GPU, Guix, TrustedHost "Core-Infrastructure", Zig, Rust, Cargo, Deno, Scorecard, Wasm] 1
   , MkNode "mesh-github-runner" [Linux, SecretAccess "GitHub-Deploy-Token"] 100
   ]
 

--- a/verification/proofs/Bag/Estate.idr
+++ b/verification/proofs/Bag/Estate.idr
@@ -28,6 +28,12 @@ estate =
   [ MkNode "mesh-laptop"        [MacOS, Guix, TrustedHost "Jonathan", Zig] 2
   , MkNode "mesh-server-1"      [Linux, GPU, Guix, TrustedHost "Core-Infrastructure", Zig, Rust, Cargo, Deno, Scorecard, Wasm] 1
   , MkNode "mesh-github-runner" [Linux, SecretAccess "GitHub-Deploy-Token"] 100
+  -- The hypatia "brain" (Elixir merge-orchestration host): emits/reads only, and
+  -- deliberately has NO `SecretAccess` capability. A merge Baton requires
+  -- `SecretAccess`, so `cheapestCapable` can never select the brain for it — the
+  -- token-free-brain invariant proved as a capability fact: the Baton must
+  -- migrate to `mesh-github-runner`.
+  , MkNode "mesh-hypatia-brain" [Linux, TrustedHost "Jonathan"] 1
   ]
 
 ||| Lookup a node by name in the estate.

--- a/verification/proofs/Bag/Protocol.idr
+++ b/verification/proofs/Bag/Protocol.idr
@@ -8,6 +8,8 @@ module Bag.Protocol
 ||| Core hardware, identity, and toolchain capabilities.
 ||| Toolchain capabilities (Zig/Rust/Cargo/Deno) let a CI-check Baton be routed
 ||| only to a node that actually has the toolchain the check needs.
+||| External-tool capabilities (Scorecard) indicate that a node has the runtime
+||| required to execute an external security/analysis tool as a Baton payload.
 public export
 data Capability
   = Linux
@@ -20,6 +22,8 @@ data Capability
   | Rust
   | Cargo
   | Deno
+  | Scorecard
+  | Wasm
 
 public export
 Eq Capability where
@@ -33,6 +37,8 @@ Eq Capability where
   Rust == Rust = True
   Cargo == Cargo = True
   Deno == Deno = True
+  Scorecard == Scorecard = True
+  Wasm == Wasm = True
   _ == _ = False
 
 ||| Check if a node's provided capabilities satisfy the Baton's requirements.
@@ -57,3 +63,5 @@ capToTag Zig              = 7
 capToTag Rust             = 8
 capToTag Cargo            = 9
 capToTag Deno             = 10
+capToTag Scorecard        = 11
+capToTag Wasm             = 12


### PR DESCRIPTION
Cross-repo counterpart to hyperpolymath/hypatia#501 — the bag-of-actions side of the live merge-orchestration actuation backend.

## What
- Registers the hypatia **brain** node `mesh-hypatia-brain` (`linux`, `trusted-host`; **no** `secret-access`) in the estate manifest **in step** across `src/estate.zig`, `nodes.scm`, and `verification/proofs/Bag/Estate.idr`. A merge Baton requires `secret_access`, held only by `mesh-github-runner`, so the decision migrates off the token-free brain to the runner (token-free-brain invariant as a capability fact).
- `bag/test/merge_orchestration_e2e_test.exs`: end-to-end proof that a hypatia merge spec (the exact `BatonEmitter.to_spec` shape) plans to `mesh-github-runner`, runs and returns `verdict=:pass`/`residue=:clean`, and **freezes-on-brain → thaws-on-runner** (attestation `hmac:verified`). The mutation gate (`{:rejected, :mutation_requires_verifier}` without a verifier) is covered too.

## Safety
No real `gh pr merge` is ever executed — the merge command is a harmless `true` stand-in, so the routing / gate / freeze / thaw / verdict path is exercised without touching a PR (and the brain holds no token anyway). The real `gh pr merge` command shape is checked through `Planner.plan` only (selects the node, executes nothing).

## Tests
- `zig build` + `zig build test` → OK.
- bag suite: **24 tests** (the 5 new E2E pass). The 3 failures are **pre-existing and unrelated** — stale tests that assume `src/estate.zig` is a dirty `zig fmt` fixture, but it is clean both before and after this change.

## Note for review
This branch is based on the latest local `main` and therefore also carries the previously-**unpushed** commit `5d820cb` (CheckBaton v2: WASI checks, tool_version, inline artifact). Only the top commit (`feat(estate): …`) is this work; `5d820cb` is your prior local work surfaced by the push.

Core-tier → **draft for owner review** (not auto-armed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)