### PR TITLE
nodes.scm: valid (list …) form (re-land dropped PR #5 follow-up)

### DIFF
--- a/nodes.scm
+++ b/nodes.scm
@@ -10,23 +10,25 @@
   #:use-module (gnu packages)
   #:export (estate-nodes))
 
+;; A proper list of node alists (each entry: name / capabilities / owner).
 (define estate-nodes
-  '((name . "mesh-laptop")
-    (capabilities . (macos guix trusted-host))
-    (owner . "Jonathan"))
-  '((name . "mesh-server-1")
-    (capabilities . (linux gpu guix trusted-host))
-    (owner . "Core-Infrastructure"))
-  '((name . "mesh-github-runner")
-    (capabilities . (linux secret-access))
-    (owner . "GitHub"))
-  ;; The hypatia "brain" (Elixir merge-orchestration host): emits/reads only and
-  ;; deliberately WITHOUT secret-access, so a merge Baton (required-cap
-  ;; secret-access) can never run here and must migrate to mesh-github-runner —
-  ;; the token-free-brain invariant. Mirrors src/estate.zig / Bag.Estate.idr.
-  '((name . "mesh-hypatia-brain")
-    (capabilities . (linux trusted-host))
-    (owner . "Jonathan")))
+  (list
+   '((name . "mesh-laptop")
+     (capabilities . (macos guix trusted-host))
+     (owner . "Jonathan"))
+   '((name . "mesh-server-1")
+     (capabilities . (linux gpu guix trusted-host))
+     (owner . "Core-Infrastructure"))
+   '((name . "mesh-github-runner")
+     (capabilities . (linux secret-access))
+     (owner . "GitHub"))
+   ;; The hypatia "brain" (Elixir merge-orchestration host): emits/reads only and
+   ;; deliberately WITHOUT secret-access, so a merge Baton (required-cap
+   ;; secret-access) can never run here and must migrate to mesh-github-runner —
+   ;; the token-free-brain invariant. Mirrors src/estate.zig / Bag.Estate.idr.
+   '((name . "mesh-hypatia-brain")
+     (capabilities . (linux trusted-host))
+     (owner . "Jonathan"))))
 
 ;; Note: In a production Guix System deployment, this would
 ;; be used to generate node-specific operating-system configurations.


### PR DESCRIPTION
Re-lands the cosmetic follow-up that was dropped when PR #5's head didn't refresh before merge. Wraps `estate-nodes` in `(list …)` so it is a proper 4-element list. Mirror file only (Zig host reads src/estate.zig). Owner-approved in the prior round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)