### PR TITLE
feat(ci): report Baton verdicts to GitHub (commit-status bridge) + nix capability

### DIFF
--- a/bag/lib/bag/github_bridge.ex
+++ b/bag/lib/bag/github_bridge.ex
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+defmodule Bag.GitHubBridge do
+  @moduledoc """
+  Discharges the `{:owes, :github_required_check}` residue (see `Bag.ActionResult`):
+  publishes a CI-check Baton verdict — produced on owned compute, **zero GitHub
+  Actions minutes** — back to a GitHub commit, so a *required* status check is
+  satisfied without a GitHub-hosted runner. This is the one bridge `docs/ci-check-baton.adoc`
+  names as "a separate cloud-native bridge ... not replaced by this Batonisation".
+
+  ## Design notes
+
+    * **Commit Status, not Check-Run.** The Checks API can only be *written* by a
+      GitHub **App** token; a personal/OAuth token (what the `gh` CLI carries)
+      cannot create check-runs. The **Commit Status** API
+      (`POST /repos/{repo}/statuses/{sha}`) *is* writable by a normal token and
+      equally satisfies a branch-protection required context (matched by the
+      `context` string). So this bridge posts a status.
+    * **Dependency-free.** It shells out to the `gh` CLI via `System.cmd/3`,
+      reusing its existing auth — no HTTP client is added to `:bag`.
+    * **Conservative mapping.** Only `:pass` maps to `success`; everything else
+      (`:fail` → `failure`, `:error` → `error`, `:suspended` → `failure`) is
+      non-green, so a check that did not truly pass can never silently satisfy a
+      *required* gate (a suspended check = no capable owned node = needs attention).
+
+  Pure argv construction (`gh_command/5`) is separated from the side-effecting
+  `report_check/5`, and the command runner is injectable (`:runner` opt), so the
+  whole flow is unit-testable without touching GitHub.
+  """
+
+  # GitHub commit-status `description` is capped at 140 characters.
+  @max_description 140
+
+  @doc "Verdict atom → GitHub commit-status `state` (only `:pass` is green)."
+  @spec state_for(atom()) :: String.t()
+  def state_for(:pass), do: "success"
+  def state_for(:error), do: "error"
+  def state_for(_other), do: "failure"
+
+  @doc """
+  Build the `gh api` argv that posts a commit status. Pure and testable.
+
+  `context` is the string a branch-protection *required status check* rule matches.
+  Options: `:description`, `:target_url` (link to the attested verdict envelope),
+  `:node` (folded into the default description).
+  """
+  @spec gh_command(String.t(), String.t(), String.t(), atom(), keyword()) :: {String.t(), [String.t()]}
+  def gh_command(repo, head_sha, context, verdict, opts \\ []) do
+    state = state_for(verdict)
+
+    description =
+      opts
+      |> Keyword.get(:description, default_description(verdict, opts))
+      |> truncate()
+
+    base = [
+      "api",
+      "--method",
+      "POST",
+      "repos/#{repo}/statuses/#{head_sha}",
+      "-f",
+      "state=#{state}",
+      "-f",
+      "context=#{context}",
+      "-f",
+      "description=#{description}"
+    ]
+
+    with_url =
+      case Keyword.get(opts, :target_url) do
+        nil -> base
+        url -> base ++ ["-f", "target_url=#{url}"]
+      end
+
+    {"gh", with_url ++ ["--jq", ".url"]}
+  end
+
+  @doc """
+  Post one verdict as a commit status. Returns `{:ok, status_url}` or
+  `{:error, {exit_code, output}}`. Pass `:runner` (a `fn cmd, args -> {out, code} end`)
+  to intercept the shell-out (defaults to the real `gh`).
+  """
+  @spec report_check(String.t(), String.t(), String.t(), atom(), keyword()) ::
+          {:ok, String.t()} | {:error, {integer(), String.t()}}
+  def report_check(repo, head_sha, context, verdict, opts \\ []) do
+    {cmd, args} = gh_command(repo, head_sha, context, verdict, opts)
+    runner = Keyword.get(opts, :runner, &default_runner/2)
+
+    case runner.(cmd, args) do
+      {out, 0} -> {:ok, String.trim(out)}
+      {out, code} -> {:error, {code, String.trim(out)}}
+    end
+  end
+
+  @doc """
+  Publish a whole `Bag.CiSweep.run/1` result to GitHub.
+
+  `context_opts` requires `:repo` (e.g. `"hyperpolymath/snifs"`) and `:head_sha`.
+  Each check's status context defaults to `"bag/<check_id>"`; override per check
+  with `:context_map` (e.g. `%{"snifs-abi" => "ABI conformance — interface drift gate"}`)
+  to satisfy an existing required-check name. `:runner` is threaded through for tests.
+
+  Returns `[{check_id, {:ok, url} | {:error, reason}}]`.
+  """
+  @spec report_sweep({[map()], map()}, keyword()) :: [{String.t(), {:ok, String.t()} | {:error, term()}}]
+  def report_sweep({results, _summary}, context_opts) do
+    repo = Keyword.fetch!(context_opts, :repo)
+    head_sha = Keyword.fetch!(context_opts, :head_sha)
+    context_map = Keyword.get(context_opts, :context_map, %{})
+    runner = Keyword.get(context_opts, :runner)
+
+    Enum.map(results, fn r ->
+      context = Map.get(context_map, r.check_id, "bag/#{r.check_id}")
+      opts = [node: r.node]
+      opts = if runner, do: Keyword.put(opts, :runner, runner), else: opts
+      {r.check_id, report_check(repo, head_sha, context, r.verdict, opts)}
+    end)
+  end
+
+  # ── internals ──────────────────────────────────────────────────────────────
+
+  defp default_runner(cmd, args), do: System.cmd(cmd, args, stderr_to_stdout: true)
+
+  defp default_description(verdict, opts) do
+    node = Keyword.get(opts, :node)
+    base = "#{verdict} via a bag-of-actions Baton on owned compute (0 GitHub minutes)"
+    if node, do: base <> " — node #{node}", else: base
+  end
+
+  defp truncate(s) when is_binary(s) do
+    if String.length(s) <= @max_description, do: s, else: String.slice(s, 0, @max_description)
+  end
+end

--- a/bag/lib/bag/mesh.ex
+++ b/bag/lib/bag/mesh.ex
@@ -70,6 +70,7 @@ defmodule Bag.Mesh do
         :deno -> "deno"
         :scorecard -> "scorecard"
         :wasm -> "wasm"
+        :nix -> "nix"
         _ -> "unknown"
       end)
       

--- a/bag/lib/mix/tasks/bag.report.ex
+++ b/bag/lib/mix/tasks/bag.report.ex
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+defmodule Mix.Tasks.Bag.Report do
+  @shortdoc "Run a Baton sweep on owned compute + post each verdict to a GitHub commit"
+  @moduledoc """
+  Run a CI-check Baton sweep on owned compute (**zero GitHub Actions minutes**) AND
+  publish each verdict back to a GitHub commit as a *status* (via `Bag.GitHubBridge`),
+  satisfying a branch-protection **required check** without a GitHub-hosted runner.
+  This is the dispatcher that makes the bag→GitHub bridge live — `bag.sweep` runs
+  the checks; `bag.report` runs them *and* reports back.
+
+      GITHUB_REPOSITORY=hyperpolymath/snifs GITHUB_SHA=<head-sha> \\
+        mix bag.report /path/to/snifs/ci-checks.exs
+
+  `GITHUB_REPOSITORY` + `GITHUB_SHA` are the standard GitHub env vars (set by the
+  triggering dispatcher; `BAG_HEAD_SHA` is accepted as a fallback for the PR head).
+  Each manifest check may carry an optional `:github_context` — the required-check
+  NAME its verdict posts to; absent, the context defaults to `bag/<check_id>`.
+
+  Exit status: `0` iff every check passed AND every status posted; `1` otherwise.
+  """
+  use Mix.Task
+
+  @impl Mix.Task
+  def run(args) do
+    Mix.Task.run("app.start")
+    {repo, head_sha} = github_context!()
+    path = List.first(args) || "../ci-checks.exs"
+    {checks, _bindings} = Code.eval_file(path)
+
+    {results, summary} = Bag.CiSweep.run(checks)
+    context_map = context_map_from(checks)
+
+    posts =
+      Bag.GitHubBridge.report_sweep({results, summary},
+        repo: repo,
+        head_sha: head_sha,
+        context_map: context_map
+      )
+
+    Enum.each(posts, fn
+      {id, {:ok, url}} -> IO.puts("#{id}\tposted\t#{url}")
+      {id, {:error, reason}} -> IO.puts(:stderr, "#{id}\tPOST-FAILED\t#{inspect(reason)}")
+    end)
+
+    IO.puts(:stderr, "bag.report: #{inspect(summary)} on owned compute (0 GitHub minutes)")
+
+    green? = Bag.CiSweep.all_passed?({results, summary})
+    posted? = Enum.all?(posts, &match?({_id, {:ok, _url}}, &1))
+
+    cond do
+      green? and posted? ->
+        IO.puts(:stderr, "bag.report: ALL PASS + posted ✅")
+
+      not posted? ->
+        IO.puts(:stderr, "bag.report: posted-with-errors ❌")
+        exit({:shutdown, 1})
+
+      true ->
+        IO.puts(:stderr, "bag.report: NOT GREEN ❌")
+        exit({:shutdown, 1})
+    end
+  end
+
+  @doc """
+  Build a `%{check_id => github_context}` map from the manifest checks that declare
+  a `:github_context`. Checks without one fall through to `Bag.GitHubBridge`'s
+  `bag/<check_id>` default. Pure — unit-tested.
+  """
+  def context_map_from(checks) do
+    checks
+    |> Enum.filter(&Map.has_key?(&1, :github_context))
+    |> Map.new(fn c -> {c.check_id, c.github_context} end)
+  end
+
+  defp github_context! do
+    repo =
+      System.get_env("GITHUB_REPOSITORY") ||
+        Mix.raise("bag.report: GITHUB_REPOSITORY not set (expected \"owner/repo\")")
+
+    sha =
+      System.get_env("GITHUB_SHA") || System.get_env("BAG_HEAD_SHA") ||
+        Mix.raise("bag.report: GITHUB_SHA (or BAG_HEAD_SHA) not set (the PR head commit)")
+
+    {repo, sha}
+  end
+end

--- a/bag/test/bag_report_test.exs
+++ b/bag/test/bag_report_test.exs
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+defmodule Mix.Tasks.Bag.ReportTest do
+  use ExUnit.Case, async: true
+
+  test "context_map_from keeps only checks that declare :github_context" do
+    checks = [
+      %{check_id: "snifs-proofs", command: ["x"], required_cap: "nix", github_context: "bag / Formal proofs (owned compute)"},
+      %{check_id: "snifs-abi", command: ["y"], required_cap: "nix", github_context: "bag / ABI conformance (owned compute)"},
+      # a check with no github_context falls through to the bag/<check_id> default
+      %{check_id: "extra", command: ["z"], required_cap: "nix"}
+    ]
+
+    assert Mix.Tasks.Bag.Report.context_map_from(checks) == %{
+             "snifs-proofs" => "bag / Formal proofs (owned compute)",
+             "snifs-abi" => "bag / ABI conformance (owned compute)"
+           }
+  end
+
+  test "context_map_from is empty when no check declares a context" do
+    assert Mix.Tasks.Bag.Report.context_map_from([%{check_id: "a", command: ["x"]}]) == %{}
+  end
+end

--- a/bag/test/github_bridge_test.exs
+++ b/bag/test/github_bridge_test.exs
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+defmodule Bag.GitHubBridgeTest do
+  use ExUnit.Case, async: true
+  alias Bag.GitHubBridge
+
+  test "verdict → commit-status state: only :pass is success" do
+    assert GitHubBridge.state_for(:pass) == "success"
+    assert GitHubBridge.state_for(:fail) == "failure"
+    assert GitHubBridge.state_for(:error) == "error"
+    # a suspended check (no capable owned node) must NOT silently pass a required gate
+    assert GitHubBridge.state_for(:suspended) == "failure"
+  end
+
+  test "gh_command posts a commit STATUS (not a check-run — a PAT can't write checks)" do
+    {"gh", args} =
+      GitHubBridge.gh_command("hyperpolymath/snifs", "deadbeef", "bag/snifs-proofs", :pass,
+        node: "mesh-server-1"
+      )
+
+    assert "api" in args
+    assert "--method" in args and "POST" in args
+    assert "repos/hyperpolymath/snifs/statuses/deadbeef" in args
+    assert "state=success" in args
+    assert "context=bag/snifs-proofs" in args
+    assert Enum.any?(args, &String.starts_with?(&1, "description="))
+    # the whole point: statuses, never the App-only check-runs endpoint
+    refute Enum.any?(args, &String.contains?(&1, "check-runs"))
+  end
+
+  test "gh_command threads target_url (link to the attested verdict envelope)" do
+    {"gh", args} =
+      GitHubBridge.gh_command("o/r", "sha", "ctx", :fail, target_url: "https://node/attest.txt")
+
+    assert "target_url=https://node/attest.txt" in args
+    assert "state=failure" in args
+  end
+
+  test "description is truncated to GitHub's 140-char commit-status limit" do
+    {"gh", args} =
+      GitHubBridge.gh_command("o/r", "sha", "ctx", :pass, node: String.duplicate("x", 300))
+
+    desc = Enum.find(args, &String.starts_with?(&1, "description="))
+    assert String.length(String.replace_prefix(desc, "description=", "")) <= 140
+  end
+
+  test "report_sweep posts one status per check, mapping verdicts + contexts (fake runner)" do
+    test_pid = self()
+
+    runner = fn cmd, args ->
+      send(test_pid, {:posted, cmd, args})
+      {"https://api.github.com/repos/o/r/statuses/1", 0}
+    end
+
+    sweep =
+      {[
+         %{check_id: "snifs-proofs", verdict: :pass, node: "mesh-server-1"},
+         %{check_id: "snifs-abi", verdict: :fail, node: "mesh-server-1"}
+       ], %{pass: 1, fail: 1}}
+
+    out =
+      GitHubBridge.report_sweep(sweep,
+        repo: "hyperpolymath/snifs",
+        head_sha: "sha1",
+        context_map: %{"snifs-abi" => "ABI conformance — interface drift gate"},
+        runner: runner
+      )
+
+    assert [{"snifs-proofs", {:ok, _}}, {"snifs-abi", {:ok, _}}] = out
+
+    posts = for _ <- 1..2, do: (receive do {:posted, "gh", args} -> Enum.join(args, " ") end)
+
+    # default context for the un-mapped check; the mapped one matches the required name
+    assert Enum.any?(posts, &(String.contains?(&1, "context=bag/snifs-proofs") and String.contains?(&1, "state=success")))
+    assert Enum.any?(posts, &(String.contains?(&1, "context=ABI conformance — interface drift gate") and String.contains?(&1, "state=failure")))
+  end
+
+  test "report_check surfaces a non-zero gh exit as {:error, {code, output}}" do
+    runner = fn _cmd, _args -> {"gh: Not Found (HTTP 404)", 1} end
+
+    assert {:error, {1, "gh: Not Found (HTTP 404)"}} =
+             GitHubBridge.report_check("o/r", "sha", "ctx", :pass, runner: runner)
+  end
+end

--- a/docs/ci-report-to-github.adoc
+++ b/docs/ci-report-to-github.adoc
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+= Reporting Baton verdicts back to GitHub — the owned-compute CI bridge
+:toc: preamble
+:icons: font
+
+`docs/ci-check-baton.adoc` shows how a CI check *runs* on owned compute with zero
+GitHub Actions minutes and freezes an attested verdict. This doc closes the last
+loop it names ("Publication ... remains a separate cloud-native bridge"): getting
+that verdict back onto a GitHub PR so a **required status check** is satisfied
+*without* a GitHub-hosted runner.
+
+== The pieces (all built + tested)
+
+[cols="1,3"]
+|===
+| `Bag.GitHubBridge` | Posts a verdict as a GitHub **commit status** (`POST /repos/{repo}/statuses/{sha}`) via the `gh` CLI. *Status, not check-run:* the Checks API needs a GitHub **App** token; a PAT (what `gh` carries) can write a status, and a status equally satisfies a branch-protection required context (matched by the `context` string). Dependency-free. Discharges `Bag.ActionResult`'s `{:owes, :github_required_check}`.
+| `mix bag.report`   | The dispatcher: runs a `Bag.CiSweep` from a manifest on a capability-matched owned node, then `GitHubBridge.report_sweep`s each verdict to the commit named by `GITHUB_REPOSITORY` + `GITHUB_SHA`. Exit 0 iff all passed *and* all posted.
+| `nix` capability   | Added across all three layers (`Protocol.idr` / `estate.zig` / `mesh.ex`); `mesh-server-1` carries it, so a `nix shell …` check routes there.
+| manifest           | The target repo ships `ci-checks.exs`; each check carries `required_cap` and an optional `github_context` (the required-check name its verdict posts to). Worked example: `hyperpolymath/snifs` `ci-checks.exs` (the proof gate + ABI conformance).
+|===
+
+== Run it (on the node)
+
+[source,sh]
+----
+# On a nix-capable owned node, with the target repo checked out at the PR head:
+cd /path/to/bag-of-actions/bag
+GITHUB_REPOSITORY=hyperpolymath/snifs GITHUB_SHA=<pr-head-sha> \
+  mix bag.report /path/to/snifs/ci-checks.exs
+# -> runs `just proof-check-all` + `just abi-conformance` on owned compute,
+#    posts two commit statuses, exits 0/1.  Zero GitHub Actions minutes.
+----
+
+== Wiring the trigger — two options
+
+The execution + report-back is done; what remains is *what kicks it off when a PR
+opens*. Pick by how much GHA you'll tolerate:
+
+*Option A — thin GHA dispatcher (~seconds of minutes, simplest).* A tiny workflow
+whose only job is to hand off to the owned node; the heavy ~20-minute run happens
+off-GHA:
+
+[source,yaml]
+----
+# .github/workflows/proofs-owned.yml (sketch — needs an SSH deploy secret)
+name: Proofs (owned compute)
+on: { pull_request: { branches: [main] } }
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest          # only a few seconds: it just SSHes out
+    steps:
+      - name: Run the gate on owned compute + report back
+        env: { SSH_KEY: ${{ secrets.BAG_NODE_SSH_KEY }} }
+        run: |
+          ssh bag@mesh-server-1 \
+            "cd ~/snifs && git fetch origin && git checkout ${{ github.event.pull_request.head.sha }} \
+             && cd ~/bag-of-actions/bag \
+             && GITHUB_REPOSITORY=${{ github.repository }} \
+                GITHUB_SHA=${{ github.event.pull_request.head.sha }} \
+                mix bag.report ~/snifs/ci-checks.exs"
+----
+
+*Option B — owned webhook (zero GHA minutes, more to stand up).* A small receiver
+on owned compute subscribed to the repo's `pull_request` webhook that runs
+`mix bag.report` directly. No GHA workflow at all. This is the full
+"dissolve the billing wall" end state; it needs a reachable HTTP endpoint + the
+webhook secret.
+
+== Branch protection
+
+Point the required contexts at the bag-posted statuses:
+
+* Add `bag / Formal proofs (owned compute)` and `bag / ABI conformance (owned compute)`
+  to `main`'s required status checks.
+* Retire the GitHub-hosted `Formal proofs — Idris2 + Lean4` / `ABI conformance — interface drift gate`
+  required contexts once the owned route is trusted (keep them advisory during cut-over).
+
+== Status / gaps
+
+Built + tested (in `bag`): `Bag.GitHubBridge` (6 tests), `mix bag.report`
+(`context_map_from` tested), the `nix` capability (idris2 + zig build green,
+`match mesh-server-1 nix` = 0), the snifs manifest. *Not* done (genuine infra,
+owner-provisioned): a reachable `nix`-capable node with the toolchain + the snifs
+checkout, the trigger (Option A's SSH secret or Option B's webhook), and the
+branch-protection cut-over. Until a node is wired, this runs on demand from the CLI.

--- a/src/estate.zig
+++ b/src/estate.zig
@@ -17,6 +17,7 @@ pub const Capability = enum(u32) {
     deno = 10,
     scorecard = 11,
     wasm = 12,
+    nix = 13,
 
     pub fn fromString(s: []const u8) ?Capability {
         if (std.mem.eql(u8, s, "linux")) return .linux;
@@ -31,6 +32,7 @@ pub const Capability = enum(u32) {
         if (std.mem.eql(u8, s, "deno")) return .deno;
         if (std.mem.eql(u8, s, "scorecard")) return .scorecard;
         if (std.mem.eql(u8, s, "wasm")) return .wasm;
+        if (std.mem.eql(u8, s, "nix")) return .nix;
         return null;
     }
 };
@@ -52,7 +54,7 @@ pub const estate = [_]Node{
     },
     .{
         .name = "mesh-server-1",
-        .capabilities = &[_]Capability{ .linux, .gpu, .guix, .trusted_host, .zig, .rust, .cargo, .deno, .scorecard, .wasm },
+        .capabilities = &[_]Capability{ .linux, .gpu, .guix, .trusted_host, .zig, .rust, .cargo, .deno, .scorecard, .wasm, .nix },
         .cost = 1,
     },
     .{

--- a/verification/proofs/Bag/Estate.idr
+++ b/verification/proofs/Bag/Estate.idr
@@ -26,7 +26,7 @@ public export
 estate : List Node
 estate =
   [ MkNode "mesh-laptop"        [MacOS, Guix, TrustedHost "Jonathan", Zig] 2
-  , MkNode "mesh-server-1"      [Linux, GPU, Guix, TrustedHost "Core-Infrastructure", Zig, Rust, Cargo, Deno, Scorecard, Wasm] 1
+  , MkNode "mesh-server-1"      [Linux, GPU, Guix, TrustedHost "Core-Infrastructure", Zig, Rust, Cargo, Deno, Scorecard, Wasm, Nix] 1
   , MkNode "mesh-github-runner" [Linux, SecretAccess "GitHub-Deploy-Token"] 100
   -- The hypatia "brain" (Elixir merge-orchestration host): emits/reads only, and
   -- deliberately has NO `SecretAccess` capability. A merge Baton requires

--- a/verification/proofs/Bag/Protocol.idr
+++ b/verification/proofs/Bag/Protocol.idr
@@ -24,6 +24,7 @@ data Capability
   | Deno
   | Scorecard
   | Wasm
+  | Nix
 
 public export
 Eq Capability where
@@ -39,6 +40,7 @@ Eq Capability where
   Deno == Deno = True
   Scorecard == Scorecard = True
   Wasm == Wasm = True
+  Nix == Nix = True
   _ == _ = False
 
 ||| Check if a node's provided capabilities satisfy the Baton's requirements.
@@ -65,3 +67,4 @@ capToTag Cargo            = 9
 capToTag Deno             = 10
 capToTag Scorecard        = 11
 capToTag Wasm             = 12
+capToTag Nix              = 13


### PR DESCRIPTION
## Summary

Closes the last loop `docs/ci-check-baton.adoc` names ("Publication ... a separate cloud-native bridge"): getting an owned-compute CI verdict back onto a GitHub PR so a **required** status check is satisfied **without a GitHub-hosted runner** (zero Actions minutes).

- **`Bag.GitHubBridge`** — posts a verdict as a GitHub **commit status** via `gh` (dependency-free). *Status, not check-run:* a PAT can write statuses (which satisfy a required context) but **not** check-runs (App-only). Discharges `Bag.ActionResult`'s `{:owes, :github_required_check}`. (6 tests)
- **`mix bag.report`** — the dispatcher: sweep on owned compute → `report_sweep` each verdict to the commit from `GITHUB_REPOSITORY`/`GITHUB_SHA`. (`context_map_from` tested)
- **`nix` capability** — across all three synced layers (`Protocol.idr` `capToTag=13`, `estate.zig` enum/`fromString`, `mesh.ex`) + `mesh-server-1` tagged. idris2 + zig build green; `match mesh-server-1 nix` → 0; fail-safe intact.
- **`docs/ci-report-to-github.adoc`** — trigger recipe (thin GHA dispatcher *or* owned webhook) + branch-protection cut-over. Worked example: `hyperpolymath/snifs` (its `ci-checks.exs` lives in that repo, not here).

## Verification
- New: **8 tests pass** (`github_bridge_test` 6 + `bag_report_test` 2).
- `idris2 --build bag.ipkg` exit 0; `zig build` exit 0; `bag_of_actions match mesh-server-1 nix` exit 0; bogus cap exit 1.
- Full suite: 32 tests, **4 failures that are pre-existing + unrelated** (a `zig fmt --check src/estate.zig` fixture expects a fail but the file is now well-formatted — flagged, not touched here).

## Not in this PR (genuine infra, owner-provisioned)
A reachable `nix`-capable node with the toolchain + a repo checkout, the trigger (SSH dispatcher or webhook), and the branch-protection cut-over to the `bag / …` contexts. Until then, `mix bag.report` runs on demand from the CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
